### PR TITLE
Setup node e2e tests against dev-next

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -242,7 +242,12 @@ jobs:
       run: npm run e2e-test-node
       env:
         E2E_TEST_ESS_IDP_URL: https://broker.pod.inrupt.com
-        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.POD_SPACES_CLIENT_ID }}
-        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.POD_SPACES_CLIENT_SECRET }}
         E2E_TEST_ESS_VC_ISSUER: https://consent.pod.inrupt.com/issue
         E2E_TEST_ESS_VC_SUBJECT: https://pod.inrupt.com/solid-client-e2e-tester-ess/profile/card#me
+        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.POD_SPACES_CLIENT_ID }}
+        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.POD_SPACES_CLIENT_SECRET }}
+        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+        E2E_TEST_DEV_NEXT_VC_ISSUER: https://consent.dev-next.inrupt.com/issue
+        E2E_TEST_DEV_NEXT_VC_SUBJECT: https://id.dev-next.inrupt.com/sdkdevnexte2e
+        E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
+        E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,15 @@ jobs:
       if: runner.os == 'Linux' && matrix.node-version == '14.x' && ${{ github.actor != 'dependabot[bot]' }}
       env:
         E2E_TEST_ESS_IDP_URL: https://broker.pod.inrupt.com
-        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.POD_SPACES_CLIENT_ID }}
-        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.POD_SPACES_CLIENT_SECRET }}
         E2E_TEST_ESS_VC_ISSUER: https://consent.pod.inrupt.com/issue
         E2E_TEST_ESS_VC_SUBJECT: https://pod.inrupt.com/solid-client-e2e-tester-ess/profile/card#me
+        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.POD_SPACES_CLIENT_ID }}
+        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.POD_SPACES_CLIENT_SECRET }}
+        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+        E2E_TEST_DEV_NEXT_VC_ISSUER: https://consent.dev-next.inrupt.com/issue
+        E2E_TEST_DEV_NEXT_VC_SUBJECT: https://id.dev-next.inrupt.com/sdkdevnexte2e
+        E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
+        E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
     # Ideally, we'd autodetect installed browsers and run them headlessly.
     # See https://github.com/DevExpress/testcafe/issues/5641
     - name: Prepare browser-based end-to-end tests


### PR DESCRIPTION
This sets up the node end-to-end tests against dev-next. The browser-based tests not being implemented yet, they'll run against dev-next when implemented.