### PR TITLE
Fix VP type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfix
+
+- Receiving a legitimate VP could be rejected by the library if it had a single
+  string as a type, which should be acceptable.
+
 The following sections document changes that have been released already:
 
 ## 0.1.2 - 2021-10-13

--- a/src/common/common.test.ts
+++ b/src/common/common.test.ts
@@ -114,6 +114,63 @@ describe("isVerifiablePresentation", () => {
       mockedPresentation.holder = "https://some.holder";
       expect(isVerifiablePresentation(mockedPresentation)).toBe(true);
     });
+
+    it("is passed a correct VP with a single type", () => {
+      const vp = JSON.parse(`{
+        "@context": [
+            "https://www.w3.org/2018/credentials/v1"
+        ],
+        "holder": "https://vc.dev-next.inrupt.com",
+        "type": "VerifiablePresentation",
+        "verifiableCredential": [
+            {
+                "@context": [
+                    "https://www.w3.org/2018/credentials/v1",
+                    "https://w3id.org/security/suites/ed25519-2020/v1",
+                    "https://w3id.org/vc-revocation-list-2020/v1",
+                    "https://consent.pod.inrupt.com/credentials/v1"
+                ],
+                "credentialStatus": {
+                    "id": "https://vc.dev-next.inrupt.com/status/niiL#0",
+                    "revocationListCredential": "https://vc.dev-next.inrupt.com/status/niiL",
+                    "revocationListIndex": "0",
+                    "type": "RevocationList2020Status"
+                },
+                "credentialSubject": {
+                    "providedConsent": {
+                        "mode": [
+                            "http://www.w3.org/ns/auth/acl#Read"
+                        ],
+                        "hasStatus": "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
+                        "forPersonalData": [
+                            "https://storage.dev-next.inrupt.com/8c6a313e-98ae-4eb2-9ab3-2df201d81a02/bookmarks/"
+                        ],
+                        "forPurpose": "https://example.org/someSpecificPurpose",
+                        "isProvidedTo": "https://pod.inrupt.com/womenofsolid/profile/card#me"
+                    },
+                    "id": "https://id.dev-next.inrupt.com/virginia",
+                    "inbox": "https://pod.inrupt.com/womenofsolid/inbox/"
+                },
+                "id": "https://vc.dev-next.inrupt.com/vc/9f0855b1-7494-4770-8c49-c3fe91d82f93",
+                "issuanceDate": "2021-10-20T07:29:20.062Z",
+                "issuer": "https://vc.dev-next.inrupt.com",
+                "proof": {
+                    "created": "2021-10-20T07:31:08.898Z",
+                    "domain": "solid",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "Q4-x1J0RqnIYBsW-O4IPskIeN_SOyUqtO8nZQdHlvz-PTwAe-L5lv2QhQHdUZpel1pEfdnll1rRD0vBdJ_svBg",
+                    "type": "Ed25519Signature2020",
+                    "verificationMethod": "https://vc.dev-next.inrupt.com/key/3eb16a3d-d31e-4f6e-b1ca-581257c69412"
+                },
+                "type": [
+                    "VerifiableCredential",
+                    "SolidAccessGrant"
+                ]
+            }
+        ]
+    }`);
+      expect(isVerifiablePresentation(vp)).toBe(true);
+    });
   });
 
   describe("returns false if", () => {

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -134,7 +134,10 @@ export function isVerifiablePresentation(
   vp: unknown | VerifiablePresentation
 ): vp is VerifiablePresentation {
   let inputIsVp = true;
-  inputIsVp = inputIsVp && Array.isArray((vp as VerifiablePresentation).type);
+  inputIsVp =
+    inputIsVp &&
+    (Array.isArray((vp as VerifiablePresentation).type) ||
+      typeof (vp as VerifiablePresentation).type === "string");
   if ((vp as VerifiablePresentation).verifiableCredential !== undefined) {
     inputIsVp =
       inputIsVp &&


### PR DESCRIPTION
It is valid for a VP to have a single type as a string, and not as an array of one string.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).