### PR TITLE
Fix revocation status value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+### Bugfix
+
+- Revoking a VC was setting the revocation status to an incorrect value, preventing
+  the revocation to actually happen.
+
 ## 0.1.3 - 2021-10-20
 
 ### Bugfix

--- a/src/revoke/revoke.test.ts
+++ b/src/revoke/revoke.test.ts
@@ -100,7 +100,7 @@ describe("revokeVerifiableCredential", () => {
           credentialStatus: [
             {
               type: "RevocationList2020Status",
-              status: "0",
+              status: "1",
             },
           ],
         }),

--- a/src/revoke/revoke.ts
+++ b/src/revoke/revoke.ts
@@ -57,7 +57,7 @@ export default async function revokeVerifiableCredential(
       credentialStatus: [
         {
           type: "RevocationList2020Status",
-          status: "0",
+          status: "1",
         },
       ],
     }),


### PR DESCRIPTION
According to https://w3c-ccg.github.io/vc-status-list-2021/#core-concept, the status should be set to "1" when revoking a VC, and not to "0" as it was done so far.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).