### PR TITLE
v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+The following sections document changes that have been released already:
+
+### 0.2.0 - 2021-10-30
+
 ### New features
 
 - `getVerifiableCredentialApiConfiguration`: If the VC service exposes a `.well-known/vc-configuration`
-  document, this fetches it, parses it, and returns known services from it.
-
-The following sections document changes that have been released already:
+  document, this function fetches it, parses it, and returns known services from it.
 
 ### 0.1.5 - 2021-10-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-vc",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-vc",
   "description": "A library to act as a client to a server implementing the W3C VC HTTP APIs.",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.js",

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -212,6 +212,7 @@ const SOLID_VC_VERIFIER_SERVICE = SOLID_VC_NS.concat("verifierService");
  *
  * @param vcServiceUrl The URL of the VC services provider. Only the domain is relevant, any provided path will be ignored.
  * @returns A map of the services available and their URLs.
+ * @since 0.2.0
  */
 export async function getVerifiableCredentialApiConfiguration(
   vcServiceUrl: URL | UrlString


### PR DESCRIPTION
This PR bumps the version to 0.2.0.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
