### PR TITLE
Explicitly fetch config discovery as JSON-LD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,22 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfixes
+
+- Looking up the configuration discovery file explicitly sets the `Accept` header
+  to `application/ld+json`, preventing the a`406 Unacceptable` response when trying
+  to dereference it as Turtle.
+
 The following sections document changes that have been released already:
 
-### 0.2.0 - 2021-10-30
+## 0.2.0 - 2021-10-30
 
 ### New features
 
 - `getVerifiableCredentialApiConfiguration`: If the VC service exposes a `.well-known/vc-configuration`
   document, this function fetches it, parses it, and returns known services from it.
 
-### 0.1.5 - 2021-10-29
+## 0.1.5 - 2021-10-29
 
 - Looking up a VC at the '/derive' endpoint was issuing incorrect requests.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3172,9 +3172,9 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.13.1.tgz",
-      "integrity": "sha512-yPdCdClyXJG4r1gzDyItnlI0dYEysLQ6jWwl3iPZFscbzc0+1QRI6VO9LbeVFUR/nIqr4qyKu4aFA4LKU6ySNw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.15.0.tgz",
+      "integrity": "sha512-XNBlOEF8wcMyDp20j0vQoWn7F8OGhaloXWjNGPhG3VpwkPN/25HniH8KPCKmnxlwi5I5dv68+BXOvYyy4T00Hw==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
         "@rdfjs/types": "^1.0.1",
@@ -3723,11 +3723,11 @@
       "dev": true
     },
     "@rdfjs/data-model": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.3.tgz",
-      "integrity": "sha512-oo9U3nEowTxxML7CZybujL3e/bty4aXHDSWanWXQxfnJQYKU6p5SCgkjeRbuVfQ9lAVfdvz68Qq5D4LtGWuKug==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
       "requires": {
-        "@types/rdf-js": "*"
+        "@rdfjs/types": ">=1.0.1"
       }
     },
     "@rdfjs/dataset": {
@@ -4075,14 +4075,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
       "dev": true
-    },
-    "@types/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
-      "requires": {
-        "rdf-js": "*"
-      }
     },
     "@types/rdfjs__dataset": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@inrupt/solid-client": "^1.13.1",
+    "@inrupt/solid-client": "^1.15.0",
     "cross-fetch": "^3.1.4"
   },
   "lint-staged": {

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -23,6 +23,7 @@ import {
   getSolidDataset,
   getThingAll,
   UrlString,
+  getJsonLdParser,
 } from "@inrupt/solid-client";
 
 export type Iri = string;
@@ -222,7 +223,10 @@ export async function getVerifiableCredentialApiConfiguration(
     vcServiceUrl.toString()
   );
 
-  const vcConfigData = await getSolidDataset(wellKnownIri.href);
+  const vcConfigData = await getSolidDataset(wellKnownIri.href, {
+    // The configuration discovery document is only available as JSON-LD.
+    parsers: { "application/ld+json": getJsonLdParser() },
+  });
 
   // The dataset should have a single blank node subject of all its triples.
   const wellKnownRootBlankNode = getThingAll(vcConfigData, {

--- a/src/common/configuration.test.ts
+++ b/src/common/configuration.test.ts
@@ -84,7 +84,7 @@ const mockVcWellKnown = (options: {
 };
 
 describe("getVerifiableCredentialApiConfiguration", () => {
-  it("builds the well-known IRI from the given VC service domain", async () => {
+  it("builds the well-known IRI from the given VC service domain, and specify the JSON-LD serialization", async () => {
     const clientModule = jest.requireMock("@inrupt/solid-client") as {
       getSolidDataset: typeof getSolidDataset;
     };
@@ -95,7 +95,12 @@ describe("getVerifiableCredentialApiConfiguration", () => {
       "https://some.example.vc/service"
     );
     expect(clientModule.getSolidDataset).toHaveBeenCalledWith(
-      "https://some.example.vc/.well-known/vc-configuration"
+      "https://some.example.vc/.well-known/vc-configuration",
+      {
+        parsers: {
+          "application/ld+json": expect.anything(),
+        },
+      }
     );
   });
 


### PR DESCRIPTION
The configuration discovery document (.well-known/vc-configuration) is only available as JSON-LD, and trying to fetch it with the default behavior of `getSolidDataset` fails with '406 unacceptable', because it tries to dereference the document as Turtle. This upgrades to the latest version of `@inrupt/solid-client`, which exports functions to explicitly parse a dataset as JSON-LD, and uses said function when looking up the configuration discovery document.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
