### PR TITLE
Rename vc-http-api to vc-api across all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **This library is still in alpha state**
 
 This library is a client library designed to interact with servers implementing
-the [W3C VC HTTP APIs](https://w3c-ccg.github.io/vc-http-api/).
+the [W3C VC HTTP APIs](https://w3c-ccg.github.io/vc-api/).
 
 More documentation will be added when the library matures.
 

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -33,7 +33,7 @@ import {
 
 /**
  * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
- * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-http-api/issuer.html).
+ * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
  *
  * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
  * @param subjectId The identifier of the VC claims' subject.
@@ -102,7 +102,7 @@ export default async function issueVerifiableCredential(
       : [credentialTypeClaims];
   }
   const credentialIssueBody = {
-    // See https://w3c-ccg.github.io/vc-http-api/issuer.html
+    // See https://w3c-ccg.github.io/vc-api/issuer.html
     credential: {
       "@context": concatenateContexts(
         defaultContext,

--- a/src/lookup/derive.ts
+++ b/src/lookup/derive.ts
@@ -31,7 +31,7 @@ import fallbackFetch from "../fetcher";
 /**
  * Look up VCs from a given holder according to a subset of their claims, such as
  * the VC type, or any property associated to the subject in the VC. The holder
- * is expected to implement the [W3C VC Holder HTTP API](https://w3c-ccg.github.io/vc-http-api/holder.html).
+ * is expected to implement the [W3C VC Holder HTTP API](https://w3c-ccg.github.io/vc-api/holder.html).
  *
  * @param holderEndpoint The `/derive` endpoint of the holder.
  * @param vcShape The subset of claims you expect the matching VCs to contain.
@@ -63,7 +63,7 @@ export default async function getVerifiableCredentialAllFromShape(
   delete credentialClaims["@context"];
   const claimsContext = vcShape["@context"];
   const credentialRequestBody = {
-    // See https://w3c-ccg.github.io/vc-http-api/holder.html
+    // See https://w3c-ccg.github.io/vc-api/holder.html
     verifiableCredential: {
       "@context": concatenateContexts(defaultContext, claimsContext),
       ...credentialClaims,

--- a/src/revoke/revoke.ts
+++ b/src/revoke/revoke.ts
@@ -25,8 +25,8 @@ import fallbackFetch from "../fetcher";
 /**
  * Revoke a given VC from a given issuer. This changes the status of the VC so that
  * subsequent verifications will fail. The issuer is expected to implement the
- * [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-http-api/issuer.html),
- * in particular [VC status update](https://w3c-ccg.github.io/vc-http-api/issuer.html#operation/updateCredentialStatus).
+ * [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html),
+ * in particular [VC status update](https://w3c-ccg.github.io/vc-api/issuer.html#operation/updateCredentialStatus).
  *
  * @param issuerEndpoint The `/status` endpoint of the holder.
  * @param credentialId The identifier of the VC to be revoked.


### PR DESCRIPTION
On Noverber 9th 2021, `vc-http-api` was renamed to `vc-api/`.<sup>1</sup> This means all https://w3c-ccg.github.io/vc-http-api/ links in this project now point to "404 Not Found" pages<sup>2</sup>.

This MR renames `vc-http-api` to `vc-api` across all files.<sup>3</sup>

## Footnotes

1. (see https://github.com/w3c-ccg/vc-api/commit/c049b8e46570fa1c64407c17f12825ffd4bd92dd)
2. Specifically, these are:
    - https://w3c-ccg.github.io/vc-http-api/
    - https://w3c-ccg.github.io/vc-http-api/holder.html
    - https://w3c-ccg.github.io/vc-http-api/issuer.html
    - https://w3c-ccg.github.io/vc-http-api/issuer.html#operation/updateCredentialStatus
3.  Specifically:
    - `README.md`
    - `src/issue/issue.ts`
    - `src/lookup/derive.ts`
    - `src/revoke/revoke.ts`


- - -
Signed-off-by: Ben Peachey <ben@muze.nl>