### PR TITLE
Use node 16.x in tests and development

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -167,7 +167,7 @@ jobs:
     - uses: actions/checkout@v2.4.0
     - uses: actions/setup-node@v2.5.0
       with:
-        node-version: '14.x'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Verify that the package can be imported in a Parcel project
       run: |
@@ -192,7 +192,7 @@ jobs:
     - uses: actions/checkout@v2.4.0
     - uses: actions/setup-node@v2.5.0
       with:
-        node-version: '14.x'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Verify that the package can be imported in a Webpack project
       run: |
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     needs: [prepare-deployment, publish-npm]
     steps:
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # To prevent conflicts of multiple jobs trying to modify the same Resource at the same time,
       # and because behaviour on different OS's is already tested by unit tests,
       # end-to-end tests only need to run on one OS:
-      if: runner.os == 'Linux' && matrix.node-version == '14.x' && github.actor != 'dependabot[bot]'
+      if: runner.os == 'Linux' && matrix.node-version == '16.x' && github.actor != 'dependabot[bot]'
       env:
         E2E_TEST_ESS_IDP_URL: https://broker.pod.inrupt.com
         E2E_TEST_ESS_VC_SERVICE: https://consent.pod.inrupt.com

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Prepare for publication to GitHub Packages
       uses: actions/setup-node@v2.5.0
       with:
-        node-version: '14.x'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Build API docs
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
     - uses: actions/checkout@v2.4.0
     - uses: actions/setup-node@v2.5.0
       with:
-        node-version: '14.x'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Verify that the package can be imported in a Parcel project
       run: |
@@ -150,7 +150,7 @@ jobs:
     - uses: actions/checkout@v2.4.0
     - uses: actions/setup-node@v2.5.0
       with:
-        node-version: '14.x'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Verify that the package can be imported in a Webpack project
       run: |
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     needs: [prepare-deployment, publish-npm]
     steps:
     - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
This PR updates the .nvmrc to use Node 16, updates the CI / CD workflows to include 16 in the test matrix and for builds, and  rebuilds the package-lock.json using NPM 8.