### PR TITLE
Deprecate sepcifying the VC subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+### Deprecation
+
+- Passing a subject ID to `issueVerifiableCredential` is now deprecated.
+
 ## 0.3.0 - 2022-01-21
 
 ### New features

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -82,7 +82,7 @@ async function internal_issueVerifiableCredential(
       credentialSubject: contextlessSubjectClaims,
     },
   };
-  const response = await (internalOptions.fetch as typeof global.fetch)(
+  const response = await (internalOptions.fetch as typeof fetch)(
     issuerEndpoint,
     {
       headers: {

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -31,34 +31,25 @@ import {
   defaultCredentialTypes,
 } from "../common/common";
 
-/**
- * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
- * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
- *
- * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
- * @param subjectId The identifier of the VC claims' subject.
- * @param subjectClaims Claims about the subject that will be attested by the VC.
- * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
- * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * This can be typically used for authentication. Note that if it is omitted, and
- * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
- * is picked up.
- * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
- * @since 0.1.0
- */
-export default async function issueVerifiableCredential(
+type OptionsType = {
+  fetch?: typeof fallbackFetch;
+};
+
+// The following extracts the logic of issueVerifiableCredential to separate it
+// from the deprecation logic. It can be merged back in issueVerifiableCredential
+// when the deprecated signature is removed altogether.
+// eslint-disable-next-line camelcase
+async function internal_issueVerifiableCredential(
   issuerEndpoint: Iri,
-  subjectId: Iri,
   subjectClaims: JsonLd,
   credentialClaims?: JsonLd,
-  options?: {
-    fetch?: typeof fallbackFetch;
-  }
+  options?: OptionsType
 ): Promise<VerifiableCredential> {
   const internalOptions = { ...options };
   if (internalOptions.fetch === undefined) {
     internalOptions.fetch = fallbackFetch;
   }
+
   // credentialClaims should contain all the claims, but not the context.
   const { "@context": subjectClaimsContext, ...contextlessSubjectClaims } =
     subjectClaims;
@@ -88,10 +79,7 @@ export default async function issueVerifiableCredential(
       ),
       type: [...defaultCredentialTypes, ...credentialTypes],
       ...nonTypeCredentialClaims,
-      credentialSubject: {
-        id: subjectId,
-        ...contextlessSubjectClaims,
-      },
+      credentialSubject: contextlessSubjectClaims,
     },
   };
   const response = await (internalOptions.fetch as typeof global.fetch)(
@@ -107,7 +95,7 @@ export default async function issueVerifiableCredential(
   if (!response.ok) {
     // TODO: use the error library when available.
     throw new Error(
-      `The VC issuing endpoint [${issuerEndpoint}] could not successfully issue a VC for provided subject [${subjectId}]: ${response.status} ${response.statusText}`
+      `The VC issuing endpoint [${issuerEndpoint}] could not successfully issue a VC: ${response.status} ${response.statusText}`
     );
   }
   const jsonData = await response.json();
@@ -122,3 +110,63 @@ export default async function issueVerifiableCredential(
     )}`
   );
 }
+
+/**
+ * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
+ * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
+ *
+ * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
+ * @param subjectId The identifier of the VC claims' subject.
+ * @param subjectClaims Claims about the subject that will be attested by the VC.
+ * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * This can be typically used for authentication. Note that if it is omitted, and
+ * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
+ * is picked up.
+ * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
+ * @since 0.1.0
+ */
+export async function issueVerifiableCredential(
+  issuerEndpoint: Iri,
+  subjectClaims: JsonLd,
+  credentialClaims?: JsonLd,
+  options?: OptionsType
+): Promise<VerifiableCredential>;
+/**
+ * @deprecated Please remove the `subjectId` parameter
+ */
+export async function issueVerifiableCredential(
+  issuerEndpoint: Iri,
+  subjectId: Iri,
+  subjectClaims: JsonLd,
+  credentialClaims?: JsonLd,
+  options?: OptionsType
+): Promise<VerifiableCredential>;
+// The signature of the implementation here is a bit confusing, but it avoid
+// breaking changes until we remove the `subjectId` completely from the API
+export async function issueVerifiableCredential(
+  issuerEndpoint: Iri,
+  subjectIdOrClaims: Iri | JsonLd,
+  subjectOrCredentialClaims: JsonLd | undefined,
+  credentialClaimsOrOptions?: JsonLd | OptionsType,
+  options?: OptionsType
+): Promise<VerifiableCredential> {
+  if (typeof subjectIdOrClaims === "string") {
+    // The function has been called with the deprecated signature, and the
+    // subjectOrCredentialClaims parameter should be ignored.
+    return internal_issueVerifiableCredential(
+      issuerEndpoint,
+      subjectOrCredentialClaims as JsonLd,
+      credentialClaimsOrOptions as JsonLd,
+      options
+    );
+  }
+  return internal_issueVerifiableCredential(
+    issuerEndpoint,
+    subjectIdOrClaims,
+    subjectOrCredentialClaims,
+    credentialClaimsOrOptions as OptionsType
+  );
+}
+
+export default issueVerifiableCredential;


### PR DESCRIPTION
Our VC issuer collects the subject ID from the authentication information, rather than from the payload it is sent. Therefore, it is confusing to make it possible to pass in a subject ID to the issuing function, when this subject ID is disregarded by the issuer and has no impact on the resulting VC.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).