### PR TITLE
0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New features
+
+-
+
 The following sections document changes that have been released already:
+
+## 0.3.1 - 2022-02-15
 
 ### Deprecation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client-vc",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client-vc",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-vc",
   "description": "A library to act as a client to a server implementing the W3C VC HTTP APIs.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.js",


### PR DESCRIPTION
This PR bumps the version to 0.3.1.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
