### PR TITLE
Feat/dereference vc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
--
+- `getVerifiableCredential`: function exported by the `./common` module to dereference
+  a VC URL and validate the obtained content.
 
 The following sections document changes that have been released already:
 

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -272,7 +272,7 @@ export async function getVerifiableCredential(
         return await response.json();
       } catch (e) {
         throw new Error(
-          `Parsing the Verifiable Credential [${vcUrl}] as JSON failed: ${e.toString()}`
+          `Parsing the Verifiable Credential [${vcUrl}] as JSON failed: ${e}`
         );
       }
     })

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -246,6 +246,14 @@ export async function getVerifiableCredentialApiConfiguration(
   };
 }
 
+/**
+ * Dereference a VC URL, and verify that the resulting content is valid.
+ *
+ * @param vcUrl The URL of the VC.
+ * @param options Options to customize the function behavior.
+ * - options.fetch: Specify a WHATWG-compatible authenticated fetch.
+ * @returns The dereferenced VC if valid. Throws otherwise.
+ */
 export async function getVerifiableCredential(
   vcUrl: UrlString,
   options?: Partial<{

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -23,6 +23,7 @@ import * as packageExports from "./index";
 import issueVerifiableCredential from "./issue/issue";
 import {
   isVerifiableCredential,
+  getVerifiableCredential,
   getVerifiableCredentialApiConfiguration,
 } from "./common/common";
 import getVerifiableCredentialAllFromShape from "./lookup/derive";
@@ -34,6 +35,7 @@ describe("exports", () => {
     expect(Object.keys(packageExports)).toEqual([
       "issueVerifiableCredential",
       "isVerifiableCredential",
+      "getVerifiableCredential",
       "getVerifiableCredentialApiConfiguration",
       "getVerifiableCredentialAllFromShape",
       "revokeVerifiableCredential",
@@ -43,6 +45,9 @@ describe("exports", () => {
       issueVerifiableCredential
     );
     expect(packageExports.isVerifiableCredential).toBe(isVerifiableCredential);
+    expect(packageExports.getVerifiableCredential).toBe(
+      getVerifiableCredential
+    );
     expect(packageExports.getVerifiableCredentialApiConfiguration).toBe(
       getVerifiableCredentialApiConfiguration
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
   JsonLd,
   VerifiableCredential,
   isVerifiableCredential,
+  getVerifiableCredential,
   getVerifiableCredentialApiConfiguration,
 } from "./common/common";
 export { default as getVerifiableCredentialAllFromShape } from "./lookup/derive";


### PR DESCRIPTION
This adds the getVerifiableCredential function to the library API. This function takes a VC IRI in, dereferences it, and validates the resulting content before returning it.

This intends at factoring out code in the acces grants library, which is likely to be useful in other contexts in the future, and which isn't specific to the access grant use case.

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).