### PR TITLE
0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
-- `getVerifiableCredential`: function exported by the `./common` module to dereference
-  a VC URL and validate the obtained content.
+-
 
 The following sections document changes that have been released already:
+
+## 0.4.0 - 2022-02-20
+
+### New features
+
+- `getVerifiableCredential`: function exported by the `./common` module to dereference
+  a VC URL and validate the obtained content.
 
 ## 0.3.1 - 2022-02-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client-vc",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client-vc",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-vc",
   "description": "A library to act as a client to a server implementing the W3C VC HTTP APIs.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.js",

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -253,6 +253,7 @@ export async function getVerifiableCredentialApiConfiguration(
  * @param options Options to customize the function behavior.
  * - options.fetch: Specify a WHATWG-compatible authenticated fetch.
  * @returns The dereferenced VC if valid. Throws otherwise.
+ * @since 0.4.0
  */
 export async function getVerifiableCredential(
   vcUrl: UrlString,


### PR DESCRIPTION
This PR bumps the version to 0.4.0.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
