### PR TITLE
Feat/filter expired vc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
--
+- `getVerifiableCredentialAllFromShape` supports a new option, `includeExpiredVc`.
+  If set to true, the Holder endpoint will return VCs that have expired and are thus
+  no longer valid. This new option defaults to false.
 
 The following sections document changes that have been released already:
 

--- a/src/lookup/derive.test.ts
+++ b/src/lookup/derive.test.ts
@@ -85,6 +85,26 @@ describe("getVerifiableCredentialAllFromShape", () => {
     );
   });
 
+  it("includes the expired VC options if requested", async () => {
+    const mockedFetch = mockFetch(mockDeriveEndpointDefaultResponse());
+    await getVerifiableCredentialAllFromShape(
+      "https://some.endpoint",
+      {
+        "@context": ["https://some.context"],
+        credentialSubject: { id: "https://some.subject/" },
+      },
+      {
+        includeExpiredVc: true,
+      }
+    );
+    expect(mockedFetch.default).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        body: expect.stringContaining("ExpiredVerifiableCredential"),
+      })
+    );
+  });
+
   it("throws if the holder returns an error", async () => {
     mockFetch(
       new Response(undefined, {

--- a/src/lookup/derive.test.ts
+++ b/src/lookup/derive.test.ts
@@ -26,6 +26,20 @@ import getVerifiableCredentialAllFromShape from "./derive";
 
 jest.mock("../fetcher");
 
+const mockFetch = (response: Response) => {
+  const mockedFetch = jest.requireMock("../fetcher") as {
+    default: typeof fetch;
+  };
+  mockedFetch.default = jest.fn(fetch).mockResolvedValue(response);
+  return mockedFetch;
+};
+
+const mockDeriveEndpointDefaultResponse = () =>
+  new Response(JSON.stringify(mockDefaultPresentation()), {
+    status: 200,
+    statusText: "OK",
+  });
+
 describe("getVerifiableCredentialAllFromShape", () => {
   it("uses the provided fetch if any", async () => {
     const mockedFetch = jest.fn() as typeof fetch;
@@ -46,32 +60,20 @@ describe("getVerifiableCredentialAllFromShape", () => {
   });
 
   it("defaults to the embedded fetcher if no fetch is provided", async () => {
-    const mockedFetch = jest.requireMock("../fetcher") as {
-      default: typeof fetch;
-    };
-    mockedFetch.default = jest.fn();
-    try {
-      await getVerifiableCredentialAllFromShape("https://some.endpoint", {
-        "@context": ["https://some.context"],
-        credentialSubject: { id: "https://some.subject/" },
-      });
-      // eslint-disable-next-line no-empty
-    } catch (_e) {}
+    const mockedFetch = mockFetch(mockDeriveEndpointDefaultResponse());
+    await getVerifiableCredentialAllFromShape("https://some.endpoint", {
+      "@context": ["https://some.context"],
+      credentialSubject: { id: "https://some.subject/" },
+    });
     expect(mockedFetch.default).toHaveBeenCalled();
   });
 
   it("posts a request with the appropriate media type", async () => {
-    const mockedFetch = jest.requireMock("../fetcher") as {
-      default: typeof fetch;
-    };
-    mockedFetch.default = jest.fn();
-    try {
-      await getVerifiableCredentialAllFromShape("https://some.endpoint", {
-        "@context": ["https://some.context"],
-        credentialSubject: { id: "https://some.subject/" },
-      });
-      // eslint-disable-next-line no-empty
-    } catch (_e) {}
+    const mockedFetch = mockFetch(mockDeriveEndpointDefaultResponse());
+    await getVerifiableCredentialAllFromShape("https://some.endpoint", {
+      "@context": ["https://some.context"],
+      credentialSubject: { id: "https://some.subject/" },
+    });
     expect(mockedFetch.default).toHaveBeenCalledWith(
       "https://some.endpoint",
       expect.objectContaining({
@@ -84,15 +86,12 @@ describe("getVerifiableCredentialAllFromShape", () => {
   });
 
   it("throws if the holder returns an error", async () => {
-    const mockedFetch = jest.requireMock("../fetcher") as {
-      default: typeof fetch;
-    };
-    mockedFetch.default = jest.fn().mockResolvedValue(
-      new Response("", {
+    mockFetch(
+      new Response(undefined, {
         status: 400,
         statusText: "Bad request",
-      }) as never
-    ) as typeof fetch;
+      })
+    );
     await expect(
       getVerifiableCredentialAllFromShape("https://some.endpoint", {
         "@context": ["https://some.context"],
@@ -102,15 +101,12 @@ describe("getVerifiableCredentialAllFromShape", () => {
   });
 
   it("throws if the holder returns non-JSON response", async () => {
-    const mockedFetch = jest.requireMock("../fetcher") as {
-      default: typeof fetch;
-    };
-    mockedFetch.default = jest.fn().mockResolvedValue(
+    mockFetch(
       new Response("Not a JSON", {
         status: 200,
         statusText: "OK",
-      }) as never
-    ) as typeof fetch;
+      })
+    );
     await expect(
       getVerifiableCredentialAllFromShape("https://some.endpoint", {
         "@context": ["https://some.context"],
@@ -120,10 +116,7 @@ describe("getVerifiableCredentialAllFromShape", () => {
   });
 
   it("throws if the holder returns JSON response which isn't a Verifiable Presentation", async () => {
-    const mockedFetch = jest.requireMock("../fetcher") as {
-      default: typeof fetch;
-    };
-    mockedFetch.default = jest.fn().mockResolvedValue(
+    mockFetch(
       new Response(
         `${JSON.stringify({
           "@context": "https://some.context",
@@ -133,8 +126,8 @@ describe("getVerifiableCredentialAllFromShape", () => {
           status: 200,
           statusText: "OK",
         }
-      ) as never
-    ) as typeof fetch;
+      )
+    );
     await expect(
       getVerifiableCredentialAllFromShape("https://some.endpoint", {
         "@context": ["https://some.context"],
@@ -144,15 +137,7 @@ describe("getVerifiableCredentialAllFromShape", () => {
   });
 
   it("returns the VCs from the obtained VP on a successful response", async () => {
-    const mockedFetch = jest.requireMock("../fetcher") as {
-      default: typeof fetch;
-    };
-    mockedFetch.default = jest.fn().mockResolvedValue(
-      new Response(JSON.stringify(mockDefaultPresentation()), {
-        status: 200,
-        statusText: "OK",
-      }) as never
-    ) as typeof fetch;
+    const mockedFetch = mockFetch(mockDeriveEndpointDefaultResponse());
     await expect(
       getVerifiableCredentialAllFromShape("https://some.endpoint", {
         "@context": ["https://some.context"],
@@ -176,10 +161,7 @@ describe("getVerifiableCredentialAllFromShape", () => {
   });
 
   it("returns an empty array if the VP contains no VCs", async () => {
-    const mockedFetch = jest.requireMock("../fetcher") as {
-      default: typeof fetch;
-    };
-    mockedFetch.default = jest.fn().mockResolvedValue(
+    mockFetch(
       new Response(
         JSON.stringify({
           ...mockDefaultPresentation(),
@@ -189,8 +171,8 @@ describe("getVerifiableCredentialAllFromShape", () => {
           status: 200,
           statusText: "OK",
         }
-      ) as never
-    ) as typeof fetch;
+      )
+    );
     await expect(
       getVerifiableCredentialAllFromShape("https://some.endpoint", {
         "@context": ["https://some.context"],

--- a/src/lookup/derive.ts
+++ b/src/lookup/derive.ts
@@ -37,10 +37,13 @@ const INCLUDE_EXPIRED_VC_OPTION = "ExpiredVerifiableCredential" as const;
  *
  * @param holderEndpoint The `/derive` endpoint of the holder.
  * @param vcShape The subset of claims you expect the matching VCs to contain.
- * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @param options Optional parameter:
+ * - `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * This can be typically used for authentication. Note that if it is omitted, and
  * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
  * is picked up.
+ * - `options.includeExpiredVc`: include expired VC matching the shape in the
+ * result set.
  * @returns A list of VCs matching the given VC shape. The list may be empty if
  * the holder does not hold any matching VC.
  * @since 0.1.0


### PR DESCRIPTION
`getVerifiableCredentialAllFromShape` now supports a new option, `includeExpiredVc`. If set to true, the Holder endpoint will return VCs that have expired and are thus no longer valid. This new option defaults to false. Note that this behaviour is off-standard, and relies on our own implementation. Striclty specification-conforming VC holders will not consider this option (but they will not break on it either).

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).