### PR TITLE
Reduce MacOS Runner Consumption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,9 @@ env:
   CI: true
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
         node-version: [16.x, 14.x, 12.x]
     steps:
     - uses: actions/checkout@v3
@@ -18,16 +16,13 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Cache node modules
-      uses: actions/cache@v2.1.7
-      env:
-        cache-name: cache-node-modules
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node${{ runner.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        cache: "npm"
+        cache-dependency-path: "**/package-lock.json"
     - run: npm ci
-    - run: npm run ci
     - run: npm run build
+    - run: npm run test
+    # TODO: Replace with shared auditing:
+    - run: npm run check-licenses
     - run: npm run e2e-test-node
       # To prevent conflicts of multiple jobs trying to modify the same Resource at the same time,
       # and because behaviour on different OS's is already tested by unit tests,
@@ -53,21 +48,4 @@ jobs:
         # Run the end-to-end tests against the code in this branch specifically:
         npm install ../../
         cd ../..
-    - run: npx package-check
-    - run: npm run check-licenses
-    # NPM audit fails because of https://github.com/advisories/GHSA-5v2h-r2cx-5xgj, 
-    # which isn't fixed in typedoc at the time of writing. Uncomment when this has
-    # been fixed.
-    # - run: npm audit --audit-level=moderate
-    - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: code-coverage-report
-        path: coverage
-    - name: Archive production artifacts
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: dist
-        path: dist
+    # TODO: Persist the e2e browser results to artifacts


### PR DESCRIPTION
Same as all the others — this does mean we're not running e2e on windows & macos right now, but we'll save that for the more major refactor of CI/CD across the repos.