### PR TITLE
security: rotate npm credentials

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Remove npm tag for the deleted branch
       run: |
         # Unfortunately GitHub Actions does not currently let us do something like
-        #     if: secrets.NPM_TOKEN != ''
+        #     if: secrets.INRUPT_NPM_TOKEN != ''
         # so simply skip the command if the env var is not set:
         if [ -n $NODE_AUTH_TOKEN ]; then npm dist-tag rm @inrupt/solid-client-vc $TAG_SLUG; fi
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
     - run: echo "Package tag [$TAG_SLUG] unpublished."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Publish an npm tag for this branch
       run: |
         # Unfortunately GitHub Actions does not currently let us do something like
-        #     if: secrets.NPM_TOKEN != ''
+        #     if: secrets.INRUPT_NPM_TOKEN != ''
         # so simply skip the command if the env var is not set:
         if [ -z $NODE_AUTH_TOKEN ]; then echo "No npm token defined; package not published."; fi
         if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --tag "$TAG_SLUG"; fi
@@ -95,7 +95,7 @@ jobs:
         if [ -n $NODE_AUTH_TOKEN ]; then echo ""; fi
         if [ -n $NODE_AUTH_TOKEN ]; then echo "    npm install @inrupt/solid-client-vc@$TAG_SLUG"; fi
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
         TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - name: Mark GitHub Deployment as successful
       uses: octokit/request-action@v2.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         echo ""
         echo "    npm install @inrupt/solid-client-vc"
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
     - name: Mark GitHub Deployment as successful
       uses: octokit/request-action@v2.x
       with:


### PR DESCRIPTION
This migrates us to a new secret managed by the GitHub Organisation for publishing to the inrupt npm organisation.