### PR TITLE
Run Sonar analysis with test coverage on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,24 @@ jobs:
           E2E_TEST_DEV_NEXT_VC_SUBJECT: https://id.dev-next.inrupt.com/sdkdevnexte2e
           E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
           E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
-    # Ideally, we'd autodetect installed browsers and run them headlessly.
-    # See https://github.com/DevExpress/testcafe/issues/5641
-    # - name: Prepare browser-based end-to-end tests
-    #   run: |
-    #     cd .codesandbox/sandbox
-    #     npm install
-    #     # Run the end-to-end tests against the code in this branch specifically:
-    #     npm install ../../
-    #     cd ../..
-    # TODO: Persist the e2e browser results to artifacts
+      # Ideally, we'd autodetect installed browsers and run them headlessly.
+      # See https://github.com/DevExpress/testcafe/issues/5641
+      # - name: Prepare browser-based end-to-end tests
+      #   run: |
+      #     cd .codesandbox/sandbox
+      #     npm install
+      #     # Run the end-to-end tests against the code in this branch specifically:
+      #     npm install ../../
+      #     cd ../..
+      # TODO: Persist the e2e browser results to artifacts
+
+      # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
+      # is not included the project will show a warning about incomplete information.
+      - run: git fetch --unshallow
+        if: ${{ matrix.node-version == '16.x' && runner.os == 'Linux' && github.actor != 'dependabot[bot]' }}
+      # Run Sonar Scan
+      - uses: SonarSource/sonarcloud-github-action@v1.6
+        if: ${{ matrix.node-version == '16.x' && runner.os == 'Linux' && github.actor != 'dependabot[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: "jsdom",
   clearMocks: true,
   collectCoverage: true,
+  coverageReporters: process.env.CI ? ["text", "lcov"] : ["text"],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=inrupt_solid-client-vc-js
+sonar.organization=inrupt
+
+# Path is relative to the sonar-project.properties file. Defaults to .
+sonar.sources=src
+
+# Path to Tests and coverage results
+#sonar.tests=test
+
+# Typescript tsconfigPath JSON file
+sonar.typescript.tsconfigPath=.
+
+# Comma-delimited list of paths to LCOV coverage report files. Paths may be absolute or relative to the project root.
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+
+sonar.exclusions=**/*.test.ts


### PR DESCRIPTION
This adds a CI workflow to run a SonarCloud Scan on each PR, including unit tests and the coverage report. The results are added to SonarCloud.