### PR TITLE
Discovery spec endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
--
+- `getVerifiableCredentialApiConfiguration` now discovers the future-compatible
+specification-compliant endpoints, as well as the legacy endpoints. 
 
 ## 0.5.0 - 2022-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The following changes have been implemented but not released yet:
 ### New features
 
 - `getVerifiableCredentialApiConfiguration` now discovers the future-compatible
-specification-compliant endpoints, as well as the legacy endpoints. 
+  specification-compliant endpoints, as well as the legacy endpoints.
 
 ## 0.5.0 - 2022-03-07
 

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -292,7 +292,28 @@ function discoverSpecCompliantEndpoints(
 /**
  * Discover the available services for a given VC service provider. The detail of
  * some of these services are given by the [W3C VC API](https://github.com/w3c-ccg/vc-api/).
- *
+ * 
+ * The returned value has two entries at its top-level, `legacy` and `specCompliant`.
+ * The former reflects the legacy (default) behavior, and relies on an ad-hoc discovery
+ * mechanism. The latter follows what the VC-API specification requires.
+ * 
+ * Note that since the specification only mandates URL patterns, what the discovery
+ * gets you is the URL where the endpoint should be available **if it is present**.
+ * Whether it actually is available or not is something you cannot assume and must
+ * explicitly check.
+ * 
+ * @example
+ * Here is how the spec-compliant endpoints are discovered:
+ * ```
+ * const config = await getVerifiableCredentialApiConfiguration("https://example.org/vc-provider");
+ * const issuer = config.specCompliant.issuerService;
+ * ```
+ * 
+ * Here is how legacy endpoints are accessed: 
+ * ```
+ * const config = await getVerifiableCredentialApiConfiguration("https://example.org/vc-provider");
+ * const legacyIssuer = config.legacy.issuerService;
+ *```
  * @param vcServiceUrl The URL of the VC services provider. Only the domain is relevant, any provided path will be ignored.
  * @returns A map of the services available and their URLs.
  * @since 0.2.0

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -194,36 +194,36 @@ export const defaultCredentialTypes = [
 /**
  * A Verifiable Credential API configuration details.
  */
-export type VerifiableCredentialApiConfiguration = 
-// Legacy endpoints 
-Partial<{
-  derivationService: UrlString;
-  issuerService: UrlString;
-  statusService: UrlString;
-  verifierService: UrlString;
-}> & 
-// Spec-compliant endpoints, available in the `specCompliant` object
-{ specCompliant: Partial<{
-  derivationService: UrlString;
-  issuerService: UrlString;
-  issuerCredentialAll: UrlString;
-  holderPresentationAll: UrlString;
-  statusService: UrlString;
-  credentialVerifierService: UrlString;
-  presentationVerifierService: UrlString;
-  queryService: UrlString;
-  exchangeService: UrlString;
-  proveService: UrlString;
-}>} &
-// Legacy endpoints, available in the `legacy` object too to ease transition
-{
-  legacy: Partial<{
-  derivationService: UrlString;
-  issuerService: UrlString;
-  statusService: UrlString;
-  verifierService: UrlString;
-  }>
-};
+export type VerifiableCredentialApiConfiguration =
+  // Legacy endpoints
+  Partial<{
+    derivationService: UrlString;
+    issuerService: UrlString;
+    statusService: UrlString;
+    verifierService: UrlString;
+  }> & {
+    // Spec-compliant endpoints, available in the `specCompliant` object
+    specCompliant: Partial<{
+      derivationService: UrlString;
+      issuerService: UrlString;
+      issuerCredentialAll: UrlString;
+      holderPresentationAll: UrlString;
+      statusService: UrlString;
+      credentialVerifierService: UrlString;
+      presentationVerifierService: UrlString;
+      queryService: UrlString;
+      exchangeService: UrlString;
+      proveService: UrlString;
+    }>;
+  } & {
+    // Legacy endpoints, available in the `legacy` object too to ease transition
+    legacy: Partial<{
+      derivationService: UrlString;
+      issuerService: UrlString;
+      statusService: UrlString;
+      verifierService: UrlString;
+    }>;
+  };
 
 // Solid VC URIs
 const SOLID_VC_NS = "http://www.w3.org/ns/solid/vc#";
@@ -232,26 +232,26 @@ const SOLID_VC_ISSUER_SERVICE = SOLID_VC_NS.concat("issuerService");
 const SOLID_VC_STATUS_SERVICE = SOLID_VC_NS.concat("statusService");
 const SOLID_VC_VERIFIER_SERVICE = SOLID_VC_NS.concat("verifierService");
 
-async function discoverLegacyEndpoints(vcServiceUrl: UrlString): Promise<VerifiableCredentialApiConfiguration["legacy"]> {
-  const wellKnownIri = new URL(
-    ".well-known/vc-configuration",
-    vcServiceUrl
-  );
-  
+async function discoverLegacyEndpoints(
+  vcServiceUrl: UrlString
+): Promise<VerifiableCredentialApiConfiguration["legacy"]> {
+  const wellKnownIri = new URL(".well-known/vc-configuration", vcServiceUrl);
+
   try {
     const vcConfigData = await getSolidDataset(wellKnownIri.href, {
       // The configuration discovery document is only available as JSON-LD.
       parsers: { "application/ld+json": getJsonLdParser() },
     });
-  
+
     // The dataset should have a single blank node subject of all its triples.
     const wellKnownRootBlankNode = getThingAll(vcConfigData, {
       acceptBlankNodes: true,
     })[0];
-  
+
     return {
       derivationService:
-        getIri(wellKnownRootBlankNode, SOLID_VC_DERIVATION_SERVICE) ?? undefined,
+        getIri(wellKnownRootBlankNode, SOLID_VC_DERIVATION_SERVICE) ??
+        undefined,
       issuerService:
         getIri(wellKnownRootBlankNode, SOLID_VC_ISSUER_SERVICE) ?? undefined,
       statusService:
@@ -261,24 +261,31 @@ async function discoverLegacyEndpoints(vcServiceUrl: UrlString): Promise<Verifia
     };
   } catch (e) {
     // The target provider may not implement the legacy endpoints, in which case
-    // the request above would fail. 
-    return {}
+    // the request above would fail.
+    return {};
   }
-  
 }
 
-function discoverSpecCompliantEndpoints(vcServiceUrl: UrlString): VerifiableCredentialApiConfiguration["specCompliant"] {
+function discoverSpecCompliantEndpoints(
+  vcServiceUrl: UrlString
+): VerifiableCredentialApiConfiguration["specCompliant"] {
   return {
-      issuerService: new URL("/credentials/issue", vcServiceUrl).toString(),
-      issuerCredentialAll: new URL("/credentials", vcServiceUrl).toString(),
-      statusService: new URL("/credentials/status", vcServiceUrl).toString(),
-      holderPresentationAll: new URL("/presentations", vcServiceUrl).toString(),
-      derivationService: new URL("/credentials/derive", vcServiceUrl).toString(),
-      exchangeService: new URL("/exchanges", vcServiceUrl).toString(),
-      proveService: new URL("/presentations/prove", vcServiceUrl).toString(),
-      queryService: new URL("/query", vcServiceUrl).toString(),
-      credentialVerifierService: new URL("/credentials/verify", vcServiceUrl).toString(),
-      presentationVerifierService: new URL("/presentations/verify", vcServiceUrl).toString()
+    issuerService: new URL("/credentials/issue", vcServiceUrl).toString(),
+    issuerCredentialAll: new URL("/credentials", vcServiceUrl).toString(),
+    statusService: new URL("/credentials/status", vcServiceUrl).toString(),
+    holderPresentationAll: new URL("/presentations", vcServiceUrl).toString(),
+    derivationService: new URL("/credentials/derive", vcServiceUrl).toString(),
+    exchangeService: new URL("/exchanges", vcServiceUrl).toString(),
+    proveService: new URL("/presentations/prove", vcServiceUrl).toString(),
+    queryService: new URL("/query", vcServiceUrl).toString(),
+    credentialVerifierService: new URL(
+      "/credentials/verify",
+      vcServiceUrl
+    ).toString(),
+    presentationVerifierService: new URL(
+      "/presentations/verify",
+      vcServiceUrl
+    ).toString(),
   };
 }
 
@@ -293,15 +300,16 @@ function discoverSpecCompliantEndpoints(vcServiceUrl: UrlString): VerifiableCred
 export async function getVerifiableCredentialApiConfiguration(
   vcServiceUrl: URL | UrlString
 ): Promise<VerifiableCredentialApiConfiguration> {
-  const legacyEndpoints = await discoverLegacyEndpoints(vcServiceUrl.toString());
+  const legacyEndpoints = await discoverLegacyEndpoints(
+    vcServiceUrl.toString()
+  );
   const specEndpoints = discoverSpecCompliantEndpoints(vcServiceUrl.toString());
   return {
     ...legacyEndpoints,
     legacy: legacyEndpoints,
-    specCompliant: specEndpoints
-  }
+    specCompliant: specEndpoints,
+  };
 }
-  
 
 /**
  * Dereference a VC URL, and verify that the resulting content is valid.

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -292,24 +292,24 @@ function discoverSpecCompliantEndpoints(
 /**
  * Discover the available services for a given VC service provider. The detail of
  * some of these services are given by the [W3C VC API](https://github.com/w3c-ccg/vc-api/).
- * 
+ *
  * The returned value has two entries at its top-level, `legacy` and `specCompliant`.
  * The former reflects the legacy (default) behavior, and relies on an ad-hoc discovery
  * mechanism. The latter follows what the VC-API specification requires.
- * 
+ *
  * Note that since the specification only mandates URL patterns, what the discovery
  * gets you is the URL where the endpoint should be available **if it is present**.
  * Whether it actually is available or not is something you cannot assume and must
  * explicitly check.
- * 
+ *
  * @example
  * Here is how the spec-compliant endpoints are discovered:
  * ```
  * const config = await getVerifiableCredentialApiConfiguration("https://example.org/vc-provider");
  * const issuer = config.specCompliant.issuerService;
  * ```
- * 
- * Here is how legacy endpoints are accessed: 
+ *
+ * Here is how legacy endpoints are accessed:
  * ```
  * const config = await getVerifiableCredentialApiConfiguration("https://example.org/vc-provider");
  * const legacyIssuer = config.legacy.issuerService;

--- a/src/common/configuration.test.ts
+++ b/src/common/configuration.test.ts
@@ -197,7 +197,7 @@ describe("getVerifiableCredentialApiConfiguration", () => {
       const result = await getVerifiableCredentialApiConfiguration(
         "https://some.example.wellknown.iri"
       );
-      
+
       expect(result.derivationService).toBeUndefined();
       expect(result.issuerService).toBeUndefined();
       expect(result.statusService).toBeUndefined();
@@ -215,7 +215,9 @@ describe("getVerifiableCredentialApiConfiguration", () => {
         "https://some.example.wellknown.iri"
       );
       expect(result.issuerService).toStrictEqual(result.legacy.issuerService);
-      expect(result.derivationService).toStrictEqual(result.legacy.derivationService);
+      expect(result.derivationService).toStrictEqual(
+        result.legacy.derivationService
+      );
     });
   });
 
@@ -224,11 +226,13 @@ describe("getVerifiableCredentialApiConfiguration", () => {
       const clientModule = jest.requireMock(
         "@inrupt/solid-client"
       ) as jest.Mocked<typeof SolidClient>;
-      clientModule.getSolidDataset.mockRejectedValueOnce(new Error("A network error"));
+      clientModule.getSolidDataset.mockRejectedValueOnce(
+        new Error("A network error")
+      );
       const result = await getVerifiableCredentialApiConfiguration(
         "https://some.example.wellknown.iri"
       );
-      expect(result.specCompliant).not.toBeUndefined();
+      expect(result.specCompliant).toBeDefined();
       expect(result.legacy).toEqual({});
     });
 
@@ -237,16 +241,34 @@ describe("getVerifiableCredentialApiConfiguration", () => {
       const result = await getVerifiableCredentialApiConfiguration(
         "https://some.example.iri"
       );
-      expect(result.specCompliant.credentialVerifierService).toStrictEqual(`${BASE_URL}/credentials/verify`);
-      expect(result.specCompliant.derivationService).toStrictEqual(`${BASE_URL}/credentials/derive`);
-      expect(result.specCompliant.exchangeService).toStrictEqual(`${BASE_URL}/exchanges`);
-      expect(result.specCompliant.holderPresentationAll).toStrictEqual(`${BASE_URL}/presentations`);
-      expect(result.specCompliant.issuerCredentialAll).toStrictEqual(`${BASE_URL}/credentials`);
-      expect(result.specCompliant.issuerService).toStrictEqual(`${BASE_URL}/credentials/issue`);
-      expect(result.specCompliant.presentationVerifierService).toStrictEqual(`${BASE_URL}/presentations/verify`);
-      expect(result.specCompliant.proveService).toStrictEqual(`${BASE_URL}/presentations/prove`);
-      expect(result.specCompliant.queryService).toStrictEqual(`${BASE_URL}/query`);
-      expect(result.specCompliant.statusService).toStrictEqual(`${BASE_URL}/credentials/status`);
+      expect(result.specCompliant.credentialVerifierService).toBe(
+        `${BASE_URL}/credentials/verify`
+      );
+      expect(result.specCompliant.derivationService).toBe(
+        `${BASE_URL}/credentials/derive`
+      );
+      expect(result.specCompliant.exchangeService).toBe(
+        `${BASE_URL}/exchanges`
+      );
+      expect(result.specCompliant.holderPresentationAll).toBe(
+        `${BASE_URL}/presentations`
+      );
+      expect(result.specCompliant.issuerCredentialAll).toBe(
+        `${BASE_URL}/credentials`
+      );
+      expect(result.specCompliant.issuerService).toBe(
+        `${BASE_URL}/credentials/issue`
+      );
+      expect(result.specCompliant.presentationVerifierService).toBe(
+        `${BASE_URL}/presentations/verify`
+      );
+      expect(result.specCompliant.proveService).toBe(
+        `${BASE_URL}/presentations/prove`
+      );
+      expect(result.specCompliant.queryService).toBe(`${BASE_URL}/query`);
+      expect(result.specCompliant.statusService).toBe(
+        `${BASE_URL}/credentials/status`
+      );
     });
   });
 });

--- a/src/common/configuration.test.ts
+++ b/src/common/configuration.test.ts
@@ -28,19 +28,19 @@ import {
   buildThing,
   setThing,
 } from "@inrupt/solid-client";
+import type * as SolidClient from "@inrupt/solid-client";
 import { getVerifiableCredentialApiConfiguration } from "./common";
 
 jest.mock("../fetcher");
 
 jest.mock("@inrupt/solid-client", () => {
-  // TypeScript can't infer the type of modules imported via Jest;
-  // skip type checking for those:
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const solidClientModule = jest.requireActual("@inrupt/solid-client") as any;
-  solidClientModule.getSolidDataset = jest.fn(
-    solidClientModule.getSolidDataset
-  );
-  solidClientModule.getWellKnownSolid = jest.fn();
+  const solidClientModule = jest.requireActual(
+    "@inrupt/solid-client"
+  ) as jest.Mocked<typeof SolidClient>;
+  solidClientModule.getSolidDataset =
+    jest.fn<typeof SolidClient["getSolidDataset"]>();
+  solidClientModule.getWellKnownSolid =
+    jest.fn<typeof SolidClient["getWellKnownSolid"]>();
   return solidClientModule;
 });
 
@@ -84,108 +84,169 @@ const mockVcWellKnown = (options: {
 };
 
 describe("getVerifiableCredentialApiConfiguration", () => {
-  it("builds the well-known IRI from the given VC service domain, and specify the JSON-LD serialization", async () => {
-    const clientModule = jest.requireMock("@inrupt/solid-client") as {
-      getSolidDataset: typeof getSolidDataset;
-    };
-    clientModule.getSolidDataset = jest
-      .fn(getSolidDataset)
-      .mockResolvedValueOnce(mockVcWellKnown({}));
-    await getVerifiableCredentialApiConfiguration(
-      "https://some.example.vc/service"
-    );
-    expect(clientModule.getSolidDataset).toHaveBeenCalledWith(
-      "https://some.example.vc/.well-known/vc-configuration",
-      {
-        parsers: {
-          "application/ld+json": expect.anything(),
-        },
-      }
-    );
-  });
-
-  it("returns the IRI of the issuer service if present", async () => {
-    const clientModule = jest.requireMock("@inrupt/solid-client") as {
-      getSolidDataset: typeof getSolidDataset;
-    };
-    clientModule.getSolidDataset = jest
-      .fn(getSolidDataset)
-      .mockResolvedValueOnce(mockVcWellKnown({ issuerPresent: true }));
-    const result = await getVerifiableCredentialApiConfiguration(
-      "https://some.example.wellknown.iri"
-    );
-    expect(result).toEqual({ issuerService: `${MOCKED_VC_SERVICE}/issue` });
-  });
-
-  it("returns the IRI of the status service if present", async () => {
-    const clientModule = jest.requireMock("@inrupt/solid-client") as {
-      getSolidDataset: typeof getSolidDataset;
-    };
-    clientModule.getSolidDataset = jest
-      .fn(getSolidDataset)
-      .mockResolvedValueOnce(mockVcWellKnown({ statusPresent: true }));
-    const result = await getVerifiableCredentialApiConfiguration(
-      "https://some.example.wellknown.iri"
-    );
-    expect(result).toEqual({ statusService: `${MOCKED_VC_SERVICE}/status` });
-  });
-
-  it("returns the IRI of the verifier service if present", async () => {
-    const clientModule = jest.requireMock("@inrupt/solid-client") as {
-      getSolidDataset: typeof getSolidDataset;
-    };
-    clientModule.getSolidDataset = jest
-      .fn(getSolidDataset)
-      .mockResolvedValueOnce(mockVcWellKnown({ verifierPresent: true }));
-    const result = await getVerifiableCredentialApiConfiguration(
-      "https://some.example.wellknown.iri"
-    );
-    expect(result).toEqual({ verifierService: `${MOCKED_VC_SERVICE}/verify` });
-  });
-
-  it("returns the IRI of the derivation service if present", async () => {
-    const clientModule = jest.requireMock("@inrupt/solid-client") as {
-      getSolidDataset: typeof getSolidDataset;
-    };
-    clientModule.getSolidDataset = jest
-      .fn(getSolidDataset)
-      .mockResolvedValueOnce(mockVcWellKnown({ derivationPresent: true }));
-    const result = await getVerifiableCredentialApiConfiguration(
-      "https://some.example.wellknown.iri"
-    );
-    expect(result).toEqual({
-      derivationService: `${MOCKED_VC_SERVICE}/derive`,
+  describe("legacy discovery", () => {
+    it("builds the well-known IRI from the given VC service domain, and specify the JSON-LD serialization", async () => {
+      const clientModule = jest.requireMock("@inrupt/solid-client") as {
+        getSolidDataset: typeof getSolidDataset;
+      };
+      clientModule.getSolidDataset = jest
+        .fn(getSolidDataset)
+        .mockResolvedValueOnce(mockVcWellKnown({}));
+      await getVerifiableCredentialApiConfiguration(
+        "https://some.example.vc/service"
+      );
+      expect(clientModule.getSolidDataset).toHaveBeenCalledWith(
+        "https://some.example.vc/.well-known/vc-configuration",
+        {
+          parsers: {
+            "application/ld+json": expect.anything(),
+          },
+        }
+      );
     });
-  });
 
-  it("returns the IRI of multiple services if present", async () => {
-    const clientModule = jest.requireMock("@inrupt/solid-client") as {
-      getSolidDataset: typeof getSolidDataset;
-    };
-    clientModule.getSolidDataset = jest
-      .fn(getSolidDataset)
-      .mockResolvedValueOnce(
+    it("returns the IRI of the issuer service if present", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockResolvedValueOnce(
+        mockVcWellKnown({ issuerPresent: true })
+      );
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      expect(result).toEqual(
+        expect.objectContaining({ issuerService: `${MOCKED_VC_SERVICE}/issue` })
+      );
+    });
+
+    it("returns the IRI of the status service if present", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockResolvedValueOnce(
+        mockVcWellKnown({ statusPresent: true })
+      );
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          statusService: `${MOCKED_VC_SERVICE}/status`,
+        })
+      );
+    });
+
+    it("returns the IRI of the verifier service if present", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockResolvedValueOnce(
+        mockVcWellKnown({ verifierPresent: true })
+      );
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          verifierService: `${MOCKED_VC_SERVICE}/verify`,
+        })
+      );
+    });
+
+    it("returns the IRI of the derivation service if present", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockResolvedValueOnce(
+        mockVcWellKnown({ derivationPresent: true })
+      );
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          derivationService: `${MOCKED_VC_SERVICE}/derive`,
+        })
+      );
+    });
+
+    it("returns the IRI of multiple services if present", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockResolvedValueOnce(
         mockVcWellKnown({ derivationPresent: true, issuerPresent: true })
       );
-    const result = await getVerifiableCredentialApiConfiguration(
-      "https://some.example.wellknown.iri"
-    );
-    expect(result).toEqual({
-      issuerService: `${MOCKED_VC_SERVICE}/issue`,
-      derivationService: `${MOCKED_VC_SERVICE}/derive`,
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          issuerService: `${MOCKED_VC_SERVICE}/issue`,
+          derivationService: `${MOCKED_VC_SERVICE}/derive`,
+        })
+      );
+    });
+
+    it("returns an empty object if no services are present", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockResolvedValueOnce(mockVcWellKnown({}));
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      
+      expect(result.derivationService).toBeUndefined();
+      expect(result.issuerService).toBeUndefined();
+      expect(result.statusService).toBeUndefined();
+      expect(result.verifierService).toBeUndefined();
+    });
+
+    it("makes the legacy endpoints available on the legacy object", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockResolvedValueOnce(
+        mockVcWellKnown({ derivationPresent: true, issuerPresent: true })
+      );
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      expect(result.issuerService).toStrictEqual(result.legacy.issuerService);
+      expect(result.derivationService).toStrictEqual(result.legacy.derivationService);
     });
   });
 
-  it("returns an empty object if no services are present", async () => {
-    const clientModule = jest.requireMock("@inrupt/solid-client") as {
-      getSolidDataset: typeof getSolidDataset;
-    };
-    clientModule.getSolidDataset = jest
-      .fn(getSolidDataset)
-      .mockResolvedValueOnce(mockVcWellKnown({}));
-    const result = await getVerifiableCredentialApiConfiguration(
-      "https://some.example.wellknown.iri"
-    );
-    expect(result).toEqual({});
+  describe("spec-compliant discovery", () => {
+    it("doesn't fail if the legacy endpoints aren't discoverable", async () => {
+      const clientModule = jest.requireMock(
+        "@inrupt/solid-client"
+      ) as jest.Mocked<typeof SolidClient>;
+      clientModule.getSolidDataset.mockRejectedValueOnce(new Error("A network error"));
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.wellknown.iri"
+      );
+      expect(result.specCompliant).not.toBeUndefined();
+      expect(result.legacy).toEqual({});
+    });
+
+    it("builds spec-compliant endpoints", async () => {
+      const BASE_URL = "https://some.example.iri";
+      const result = await getVerifiableCredentialApiConfiguration(
+        "https://some.example.iri"
+      );
+      expect(result.specCompliant.credentialVerifierService).toStrictEqual(`${BASE_URL}/credentials/verify`);
+      expect(result.specCompliant.derivationService).toStrictEqual(`${BASE_URL}/credentials/derive`);
+      expect(result.specCompliant.exchangeService).toStrictEqual(`${BASE_URL}/exchanges`);
+      expect(result.specCompliant.holderPresentationAll).toStrictEqual(`${BASE_URL}/presentations`);
+      expect(result.specCompliant.issuerCredentialAll).toStrictEqual(`${BASE_URL}/credentials`);
+      expect(result.specCompliant.issuerService).toStrictEqual(`${BASE_URL}/credentials/issue`);
+      expect(result.specCompliant.presentationVerifierService).toStrictEqual(`${BASE_URL}/presentations/verify`);
+      expect(result.specCompliant.proveService).toStrictEqual(`${BASE_URL}/presentations/prove`);
+      expect(result.specCompliant.queryService).toStrictEqual(`${BASE_URL}/query`);
+      expect(result.specCompliant.statusService).toStrictEqual(`${BASE_URL}/credentials/status`);
+    });
   });
 });

--- a/src/verify/verify.test.ts
+++ b/src/verify/verify.test.ts
@@ -99,7 +99,7 @@ describe("isValidVc", () => {
     mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
       verifierService: "https://some.vc.verifier",
       legacy: {},
-      specCompliant: {}
+      specCompliant: {},
     });
     mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
@@ -211,7 +211,7 @@ describe("isValidVc", () => {
     ).mockResolvedValueOnce({
       verifierService: "https://some.vc.verifier",
       legacy: {},
-      specCompliant: {}
+      specCompliant: {},
     });
     mocked(isVerifiableCredential).mockReturnValueOnce(true);
 
@@ -237,7 +237,8 @@ describe("isValidVc", () => {
   it("throws if no verification endpoint is discovered", async () => {
     mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
       legacy: {},
-      specCompliant: {}});
+      specCompliant: {},
+    });
     mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
       .fn(global.fetch)

--- a/src/verify/verify.test.ts
+++ b/src/verify/verify.test.ts
@@ -98,6 +98,8 @@ describe("isValidVc", () => {
   it("sends the given vc to the verify endpoint", async () => {
     mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
       verifierService: "https://some.vc.verifier",
+      legacy: {},
+      specCompliant: {}
     });
     mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
@@ -208,6 +210,8 @@ describe("isValidVc", () => {
       getVerifiableCredentialApiConfiguration
     ).mockResolvedValueOnce({
       verifierService: "https://some.vc.verifier",
+      legacy: {},
+      specCompliant: {}
     });
     mocked(isVerifiableCredential).mockReturnValueOnce(true);
 
@@ -231,7 +235,9 @@ describe("isValidVc", () => {
   });
 
   it("throws if no verification endpoint is discovered", async () => {
-    mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({});
+    mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
+      legacy: {},
+      specCompliant: {}});
     mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
       .fn(global.fetch)


### PR DESCRIPTION
This adds discovery for the spec-defined endpoints. The legacy discovery method is based on a .well-known resource being looked up. The spec actually just requires the endpoints to follow specific patterns from the provider's base URL.

Note that the discovery method just builds where the endpoint would be available **if it exists**, without actually checking whether it exists or not. That was the initial way I implemented this with https://github.com/inrupt/solid-client-vc-js/commit/0729200a69a92d63c5c865f50e2fcf37547c2484, but it would mean a bunch of requests are sent on each discovery call, a majority of them not being required at all. So instead, the caller will have to handle the specific endpoint they want to access being present or not, which is what they would have done with the discovery method anyway.

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).