### PR TITLE
Support Verifiable Presentation Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The following changes have been implemented but not released yet:
 
 - `getVerifiableCredentialApiConfiguration` now discovers the future-compatible
   specification-compliant endpoints, as well as the legacy endpoints.
+- A `query` function is added from the top-level export and the `@inrupt/solid-client-vc/query` submodule. It implements the Verifiable Presentation Request mechanism as described in https://w3c-ccg.github.io/vp-request-spec/. An important note is that we make the assumption that an endpoint supporting Verifiable Presentation Request is available at a /query path, which is outside of the VC API specification scope. This assumption is used to distinguish new endpoints vs legacy endpoints. Currently, only Query by Example VPRs are supported, which is similar to the legacy behavior in a lot of ways. The existing `getVerifiableCredentialAllFromShape` function now supports both legacy and VPR-compliant endpoints.
+
 
 ## 0.5.0 - 2022-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The following changes have been implemented but not released yet:
   specification-compliant endpoints, as well as the legacy endpoints.
 - A `query` function is added from the top-level export and the `@inrupt/solid-client-vc/query` submodule. It implements the Verifiable Presentation Request mechanism as described in https://w3c-ccg.github.io/vp-request-spec/. An important note is that we make the assumption that an endpoint supporting Verifiable Presentation Request is available at a /query path, which is outside of the VC API specification scope. This assumption is used to distinguish new endpoints vs legacy endpoints. Currently, only Query by Example VPRs are supported, which is similar to the legacy behavior in a lot of ways. The existing `getVerifiableCredentialAllFromShape` function now supports both legacy and VPR-compliant endpoints.
 
-
 ## 0.5.0 - 2022-03-07
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "./common": "./dist/common/common.mjs",
     "./issue": "./dist/issue/issue.mjs",
     "./derive": "./dist/lookup/derive.mjs",
+    "./query": "./dist/lookup/query.mjs",
     "./revoke": "./dist/revoke/revoke.mjs",
     "./verify": "./dist/verify/verify"
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,6 +29,7 @@ import {
 import getVerifiableCredentialAllFromShape from "./lookup/derive";
 import revokeVerifiableCredential from "./revoke/revoke";
 import isValidVc from "./verify/verify";
+import { query } from "./lookup/query";
 
 describe("exports", () => {
   it("includes all of the expected functions", () => {
@@ -38,6 +39,7 @@ describe("exports", () => {
       "getVerifiableCredential",
       "getVerifiableCredentialApiConfiguration",
       "getVerifiableCredentialAllFromShape",
+      "query",
       "revokeVerifiableCredential",
       "isValidVc",
     ]);
@@ -58,5 +60,6 @@ describe("exports", () => {
       revokeVerifiableCredential
     );
     expect(packageExports.isValidVc).toBe(isValidVc);
+    expect(packageExports.query).toBe(query);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,14 +20,17 @@
 //
 
 export { default as issueVerifiableCredential } from "./issue/issue";
+export type { Iri, JsonLd, VerifiableCredential } from "./common/common";
 export {
-  Iri,
-  JsonLd,
-  VerifiableCredential,
   isVerifiableCredential,
   getVerifiableCredential,
   getVerifiableCredentialApiConfiguration,
 } from "./common/common";
 export { default as getVerifiableCredentialAllFromShape } from "./lookup/derive";
+export { query } from "./lookup/query";
+export type {
+  QueryByExample,
+  VerifiablePresentationRequest,
+} from "./lookup/query";
 export { default as revokeVerifiableCredential } from "./revoke/revoke";
 export { default as isValidVc } from "./verify/verify";

--- a/src/lookup/derive.ts
+++ b/src/lookup/derive.ts
@@ -23,12 +23,73 @@ import {
   concatenateContexts,
   defaultContext,
   Iri,
-  isVerifiablePresentation,
   VerifiableCredential,
 } from "../common/common";
 import fallbackFetch from "../fetcher";
+import { query, VerifiablePresentationRequest } from "./query";
 
 const INCLUDE_EXPIRED_VC_OPTION = "ExpiredVerifiableCredential" as const;
+
+/**
+ * This creates the proprietary data structure used for querying the legacy /derive
+ * endpoint of ESS.
+ *
+ * @param vcShape The VC example used for the VP request
+ * @param includeExpiredVc An option to query for expired VC as well
+ * @returns A legacy object expected by the /derive endpoint of the ESS 2.0 VC service
+ */
+function buildLegacyQuery(
+  vcShape: Partial<VerifiableCredential>,
+  includeExpiredVc: boolean
+) {
+  // credentialClaims should contain all the claims, but not the context.
+  // const { "@context": claimsContext, ...credentialClaims } = vcShape;
+  // The following lines refactor the previous deconstruction in order to work
+  // around a misalignment between `rollup-plugin-typescript2` and NodeJS.
+  // Issue tracking: https://github.com/ezolenko/rollup-plugin-typescript2/issues/282
+  const credentialClaims = { ...vcShape };
+  delete credentialClaims["@context"];
+  const claimsContext = vcShape["@context"];
+  const credentialRequestBody: {
+    verifiableCredential: Partial<VerifiableCredential>;
+    options?: { include: typeof INCLUDE_EXPIRED_VC_OPTION };
+  } = {
+    // See https://w3c-ccg.github.io/vc-api/holder.html
+    verifiableCredential: {
+      "@context": concatenateContexts(defaultContext, claimsContext),
+      ...credentialClaims,
+    },
+  };
+  if (includeExpiredVc) {
+    credentialRequestBody.options = {
+      include: INCLUDE_EXPIRED_VC_OPTION,
+    };
+  }
+
+  return credentialRequestBody;
+}
+
+/**
+ * See https://w3c-ccg.github.io/vp-request-spec/#query-by-example.
+ * @param vcShape The VC example used for the VP request
+ * @returns A Query by Example VP Request based on the provided example.
+ */
+function buildQueryByExample(
+  vcShape: Partial<VerifiableCredential>
+): VerifiablePresentationRequest {
+  return {
+    query: [
+      {
+        type: "QueryByExample",
+        credentialQuery: [
+          {
+            example: vcShape,
+          },
+        ],
+      },
+    ],
+  };
+}
 
 /**
  * Look up VCs from a given holder according to a subset of their claims, such as
@@ -60,56 +121,20 @@ export default async function getVerifiableCredentialAllFromShape(
   if (internalOptions.fetch === undefined) {
     internalOptions.fetch = fallbackFetch;
   }
-  // credentialClaims should contain all the claims, but not the context.
-  // const { "@context": claimsContext, ...credentialClaims } = vcShape;
-  // The following lines refactor the previous deconstruction in order to work
-  // around a misalignment between `rollup-plugin-typescript2` and NodeJS.
-  // Issue tracking: https://github.com/ezolenko/rollup-plugin-typescript2/issues/282
-  const credentialClaims = { ...vcShape };
-  delete credentialClaims["@context"];
-  const claimsContext = vcShape["@context"];
-  const credentialRequestBody: {
-    verifiableCredential: Partial<VerifiableCredential>;
-    options?: { include: typeof INCLUDE_EXPIRED_VC_OPTION };
-  } = {
-    // See https://w3c-ccg.github.io/vc-api/holder.html
-    verifiableCredential: {
-      "@context": concatenateContexts(defaultContext, claimsContext),
-      ...credentialClaims,
-    },
-  };
-  if (internalOptions.includeExpiredVc) {
-    credentialRequestBody.options = {
-      include: INCLUDE_EXPIRED_VC_OPTION,
-    };
-  }
-  const response = await internalOptions.fetch(holderEndpoint, {
-    headers: {
-      "Content-Type": "application/json",
-    },
-    method: "POST",
-    body: JSON.stringify(credentialRequestBody),
+  // The request payload depends on the target endpoint.
+  const vpRequest = holderEndpoint.endsWith("/query")
+    ? // The target endpoint is spec-compliant, and uses a standard VP request.
+      // This is based on an implementation-specific assumption about the endpoint
+      // being available under the /query path.
+      buildQueryByExample(vcShape)
+    : // The target endpoint is legacy, and uses a proprietary request format.
+      (buildLegacyQuery(
+        vcShape,
+        options?.includeExpiredVc ?? false
+        // The legacy proprietary format is casted as a VP request to be passed to the `query` function.
+      ) as unknown as VerifiablePresentationRequest);
+  const vp = await query(holderEndpoint, vpRequest, {
+    fetch: options?.fetch ?? fallbackFetch,
   });
-  if (!response.ok) {
-    throw new Error(
-      `The holder [${holderEndpoint}] returned an error: ${response.status} ${response.statusText}`
-    );
-  }
-
-  let data;
-  try {
-    data = await response.json();
-  } catch (e) {
-    throw new Error(
-      `The holder [${holderEndpoint}] did not return a valid JSON response: parsing failed with error ${e}`
-    );
-  }
-  if (!isVerifiablePresentation(data)) {
-    throw new Error(
-      `The holder [${holderEndpoint}] did not return a Verifiable Presentation: ${JSON.stringify(
-        data
-      )}`
-    );
-  }
-  return data.verifiableCredential ?? [];
+  return vp.verifiableCredential ?? [];
 }

--- a/src/lookup/derive.ts
+++ b/src/lookup/derive.ts
@@ -44,23 +44,16 @@ function buildLegacyQuery(
 ) {
   // credentialClaims should contain all the claims, but not the context.
   const { "@context": claimsContext, ...credentialClaims } = vcShape;
-  const credentialRequestBody: {
-    verifiableCredential: Partial<VerifiableCredential>;
-    options?: { include: typeof INCLUDE_EXPIRED_VC_OPTION };
-  } = {
+  return {
     // See https://w3c-ccg.github.io/vc-api/holder.html
     verifiableCredential: {
       "@context": concatenateContexts(defaultContext, claimsContext),
       ...credentialClaims,
     },
+    options: {
+      include: includeExpiredVc ? INCLUDE_EXPIRED_VC_OPTION : undefined,
+    },
   };
-  if (includeExpiredVc) {
-    credentialRequestBody.options = {
-      include: INCLUDE_EXPIRED_VC_OPTION,
-    };
-  }
-
-  return credentialRequestBody;
 }
 
 /**

--- a/src/lookup/derive.ts
+++ b/src/lookup/derive.ts
@@ -43,13 +43,7 @@ function buildLegacyQuery(
   includeExpiredVc: boolean
 ) {
   // credentialClaims should contain all the claims, but not the context.
-  // const { "@context": claimsContext, ...credentialClaims } = vcShape;
-  // The following lines refactor the previous deconstruction in order to work
-  // around a misalignment between `rollup-plugin-typescript2` and NodeJS.
-  // Issue tracking: https://github.com/ezolenko/rollup-plugin-typescript2/issues/282
-  const credentialClaims = { ...vcShape };
-  delete credentialClaims["@context"];
-  const claimsContext = vcShape["@context"];
+  const { "@context": claimsContext, ...credentialClaims } = vcShape;
   const credentialRequestBody: {
     verifiableCredential: Partial<VerifiableCredential>;
     options?: { include: typeof INCLUDE_EXPIRED_VC_OPTION };

--- a/src/lookup/query.test.ts
+++ b/src/lookup/query.test.ts
@@ -1,0 +1,152 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { jest, it, describe, expect } from "@jest/globals";
+import { query, QueryByExample } from "./query";
+import type * as Fetcher from "../fetcher";
+import { mockDefaultPresentation } from "../common/common.mock";
+
+jest.mock("../fetcher");
+
+const mockRequest: QueryByExample = {
+  type: "QueryByExample",
+  credentialQuery: [
+    {
+      reason: "Some reason",
+      example: {
+        type: ["Some credential type"],
+      },
+    },
+  ],
+};
+
+describe("query", () => {
+  describe("by example", () => {
+    it("uses the provided fetch if any", async () => {
+      const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response(JSON.stringify(mockDefaultPresentation()), {
+          status: 200,
+        })
+      );
+      await query(
+        "https://some.endpoint/query",
+        { query: [mockRequest] },
+        { fetch: mockedFetch }
+      );
+      expect(mockedFetch).toHaveBeenCalled();
+    });
+
+    it("defaults to the embedded fetcher if no fetch is provided", async () => {
+      const mockedFetch = jest.requireMock("../fetcher") as jest.Mocked<
+        typeof Fetcher
+      >;
+      mockedFetch.default.mockResolvedValueOnce(
+        new Response(JSON.stringify(mockDefaultPresentation()), {
+          status: 200,
+        })
+      );
+      await query("https://some.endpoint/query", { query: [mockRequest] });
+      expect(mockedFetch.default).toHaveBeenCalled();
+    });
+
+    it("throws if the given endpoint returns an error", async () => {
+      const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response(undefined, {
+          status: 404,
+        })
+      );
+      await expect(() =>
+        query(
+          "https://example.org/query",
+          { query: [mockRequest] },
+          { fetch: mockedFetch }
+        )
+      ).rejects.toThrow();
+    });
+
+    it("throws if the endpoint responds with a non-JSON payload", async () => {
+      const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response("Not JSON", {
+          status: 200,
+        })
+      );
+      await expect(() =>
+        query(
+          "https://example.org/query",
+          { query: [mockRequest] },
+          { fetch: mockedFetch }
+        )
+      ).rejects.toThrow();
+    });
+
+    it("throws if the endpoint responds with a non-VP payload", async () => {
+      const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response(JSON.stringify({ json: "but not a VP" }), {
+          status: 200,
+        })
+      );
+      await expect(() =>
+        query(
+          "https://example.org/query",
+          { query: [mockRequest] },
+          { fetch: mockedFetch }
+        )
+      ).rejects.toThrow();
+    });
+
+    it("posts a request with the appropriate media type", async () => {
+      const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response(JSON.stringify(mockDefaultPresentation()), {
+          status: 200,
+        })
+      );
+      await query(
+        "https://some.endpoint/query",
+        { query: [mockRequest] },
+        { fetch: mockedFetch }
+      );
+      expect(mockedFetch).toHaveBeenCalledWith(
+        "https://some.endpoint/query",
+        expect.objectContaining({
+          headers: {
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        })
+      );
+    });
+
+    it("returns the VP sent by the endpoint", async () => {
+      const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response(JSON.stringify(mockDefaultPresentation()), {
+          status: 200,
+        })
+      );
+      await expect(
+        query(
+          "https://example.org/query",
+          { query: [mockRequest] },
+          { fetch: mockedFetch }
+        )
+      ).resolves.toStrictEqual(mockDefaultPresentation());
+    });
+  });
+});

--- a/src/lookup/query.ts
+++ b/src/lookup/query.ts
@@ -1,0 +1,136 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import {
+  Iri,
+  isVerifiablePresentation,
+  VerifiableCredential,
+  VerifiablePresentation,
+} from "../common/common";
+import fallbackFetch from "../fetcher";
+
+/**
+ * Based on https://w3c-ccg.github.io/vp-request-spec/#query-by-example.
+ */
+export type QueryByExample = {
+  type: "QueryByExample";
+  credentialQuery: {
+    required?: boolean;
+    reason?: string;
+    example: Partial<VerifiableCredential> & {
+      credentialSchema?: {
+        id: string;
+        type: string;
+      };
+      trustedIssuer?: {
+        required: boolean;
+        issuer: string;
+      }[];
+    };
+  }[];
+};
+
+/**
+ * A VP request is a standard way of getting a Verifiable Presentation matching
+ * the requestor's needs.
+ *
+ * Note: Currently, only the QueryByExample type is implemented, but support for
+ * other query types may be added in the future.
+ */
+export type VerifiablePresentationRequest = {
+  query: QueryByExample[];
+  challenge?: string;
+  domain?: string;
+};
+
+/**
+ * Send a Verifiable Presentation Request to a query endpoint in order to retrieve
+ * all Verifiable Credentials matching the query, wrapped in a single Presentation.
+ * 
+ * @example The following shows how to query for credentials of a certain type. Adding
+ * a reason to the request is helpful when interacting with a user. The resulting
+ * Verifiable Presentation will wrap zero or more Verifiable Credentials.
+ * 
+ * ```
+ * const verifiablePresentation = await query(
+    "https://example.org/query", { 
+      query: [{
+        type: "QueryByExample",
+        credentialQuery: [
+          {
+            reason: "Some reason",
+            example: {
+              type: ["SomeCredentialType"],
+            },
+          },
+        ],
+      }]
+    },
+    { fetch: session.fetch }
+  );
+ * ```
+ *
+ * @param queryEndpoint URL of the query endpoint.
+ * @param vpRequest VP Request object, compliant with https://w3c-ccg.github.io/vp-request-spec
+ * @param options Options object, including an authenticated `fetch`.
+ * @returns The resulting Verifiable Presentation wrapping all the Credentials matching the query.
+ */
+export async function query(
+  queryEndpoint: Iri,
+  vpRequest: VerifiablePresentationRequest,
+  options?: Partial<{
+    fetch: typeof fallbackFetch;
+  }>
+): Promise<VerifiablePresentation> {
+  const internalOptions = { ...options };
+  if (internalOptions.fetch === undefined) {
+    internalOptions.fetch = fallbackFetch;
+  }
+  const response = await internalOptions.fetch(queryEndpoint, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+    body: JSON.stringify(vpRequest),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `The query endpoint [${queryEndpoint}] returned an error: ${response.status} ${response.statusText}`
+    );
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (e) {
+    throw new Error(
+      `The holder [${queryEndpoint}] did not return a valid JSON response: parsing failed with error ${e}`
+    );
+  }
+  if (!isVerifiablePresentation(data)) {
+    throw new Error(
+      `The holder [${queryEndpoint}] did not return a Verifiable Presentation: ${JSON.stringify(
+        data
+      )}`
+    );
+  }
+  return data;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,7 @@
       "src/issue/issue.ts",
       "src/common/common.ts",
       "src/lookup/derive.ts",
+      "src/lookup/query.ts",
       "src/revoke/revoke.ts",
       "src/verify/verify.ts",
     ],


### PR DESCRIPTION
The legacy VC lookup mechanism relies on an ad-hoc object, and uses the /derive endpoint, which is actually not meant for querying but rather for selective disclosure. This introduces a query function which implements the Verifiable Presentation Request mechanism as described in https://w3c-ccg.github.io/vp-request-spec/. An important note is that we make the assumption that an endpoint supporting Verifiable Presentation Request is available at a /query path, which is outside of the VC API specification scope. This assumption is used to distinguish new endpoints vs legacy endpoints.

Currently, only Query by Example VPRs are supported, which is similar to the legacy behavior in a lot of ways. The legacy getVerifiableCredentialAllFromShape function now supports both legacy and VPR-compliant endpoints.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [X] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).