### PR TITLE
Fix: pass credentialSubject to getVerifiableCredentialAllFromShape

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -185,7 +185,7 @@ describe("End-to-end verifiable credentials tests for environment", () => {
     it("can revoke a VC", async () => {
       const result = await getVerifiableCredentialAllFromShape(
         new URL("derive", env.vcProvider).href,
-        {},
+        { credentialSubject: { id: session.info.webId as string } },
         {
           fetch: session.fetch,
         }


### PR DESCRIPTION
Fixes failing e2e test due to not passing the credential subject id. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
