### PR TITLE
Disable computing coverage on e2e tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ const baseConfig: ArrayElement<NonNullable<Config["projects"]>> = {
   // deliberately set to an empty array to allow including node_modules when transforming code:
   transformIgnorePatterns: [],
   modulePathIgnorePatterns: ["dist/"],
-  coveragePathIgnorePatterns: [".*.spec.ts", "dist/"],
+  coveragePathIgnorePatterns: [".*.spec.ts", "dist/", "node_modules/", ".*\.mock\..*"],
   clearMocks: true,
   injectGlobals: false,
 };
@@ -25,10 +25,10 @@ export default {
   //    levels should be adjust back to 100 as soon as full coverage is achieved again.
   coverageThreshold: {
     global: {
-      branches: 50,
-      functions: 48,
-      lines: 67,
-      statements: 68,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
     },
   },
   injectGlobals: false,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:eslint": "eslint --config .eslintrc.js \"src/\" \"e2e/\"",
     "lint:prettier": "prettier \"{src,e2e}/**/*.{ts,tsx,js,jsx,css}\" \"**/*.{md,mdx,yml}\"",
     "test": "jest --selectProjects browser",
-    "test:e2e:node": "jest --selectProjects e2e-node",
+    "test:e2e:node": "jest --selectProjects e2e-node --collectCoverage false",
     "test:e2e:browser": "echo \"This project has no e2e browser tests\"",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
Line coverage is not something that is useful when running end-to-end tests. Fixing this also allows to restore the original line coverage trigger.
