### PR TITLE
docs: fix typo in README.md and docs related to environments supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the [W3C VC HTTP APIs](https://w3c-ccg.github.io/vc-api/).
 
 More documentation will be added when the library matures.
 
-## Supported environment
+## Supported environments
 
 Our JavaScript Client Libraries use relatively modern JavaScript, aligned with
 the [ES2018](https://262.ecma-international.org/9.0/) Specification features, we
@@ -21,8 +21,8 @@ ship both [ESM](https://nodejs.org/docs/latest-v16.x/api/esm.html) and
 [CommonJS](https://nodejs.org/docs/latest-v16.x/api/modules.html), with type
 definitions for TypeScript alongside.
 
-This mean that we only support environments (browsers or runtimes) that were
-released after mid-2018 out of the box, if you wish to target these
+This means that out of the box, we only support environments (browsers or
+runtimes) that were released after mid-2018, if you wish to target other (older)
 environments, then you will need to cross-compile our SDKs via the use of
 [Babel](https://babeljs.io), [webpack](https://webpack.js.org/),
 [SWC](https://swc.rs/), or similar.
@@ -35,6 +35,11 @@ and `String.prototype.endsWith`.
 Additionally, when using this package in an environment other than Node.js, you
 will need [a polyfill for Node's `buffer`
 module](https://www.npmjs.com/package/buffer).
+
+### Node.js Support
+
+Our JavaScript Client Libraries track Node.js [LTS
+releases](https://nodejs.org/en/about/releases/), and support 14.x, and 16.x.
 
 ## Changelog
 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -30,20 +30,35 @@ Changelog
 See `the release
 notes <https://github.com/inrupt/solid-client-vc-js/blob/main/CHANGELOG.md>`__.
 
-Browser support
-~~~~~~~~~~~~~~~
+Supported environments
+~~~~~~~~~~~~~~~~~~~~~~
 
-Our JavaScript Client Libraries use relatively modern JavaScript
-features that will work in all commonly-used browsers, except Internet
-Explorer. If you need support for Internet Explorer, it is recommended
-to pass them through a tool like `Babel <https://babeljs.io>`__, and to
-add polyfills for e.g. ``Map``, ``Set``, ``Promise``, ``Headers``,
-``Array.prototype.includes``, ``Object.entries`` and
-``String.prototype.endsWith``.
+Our JavaScript Client Libraries use relatively modern JavaScript, aligned with
+the `ES2018 <https://262.ecma-international.org/9.0/>`__ Specification features, we
+ship both `ESM <https://nodejs.org/docs/latest-v16.x/api/esm.html>`__ and
+`CommonJS <https://nodejs.org/docs/latest-v16.x/api/modules.html>`__, with type
+definitions for TypeScript alongside.
+
+This means that out of the box, we only support environments (browsers or
+runtimes) that were released after mid-2018, if you wish to target other (older)
+environments, then you will need to cross-compile our SDKs via the use of `Babel
+<https://babeljs.io>`__, `webpack <https://webpack.js.org/>`__, `SWC
+<https://swc.rs/>`__, or similar.
+
+If you need support for Internet Explorer, it is recommended to pass them
+through a tool like `Babel <https://babeljs.io>`__, and to add polyfills for
+e.g. ``Map``, ``Set``, ``Promise``, ``Headers``, ``Array.prototype.includes``,
+``Object.entries`` and ``String.prototype.endsWith``.
 
 Additionally, when using this package in an environment other than Node.js, you
 will need `a polyfill for Node's buffer module
 <https://www.npmjs.com/package/buffer>`__.
+
+Node.js Support
+^^^^^^^^^^^^^^^
+
+Our JavaScript Client Libraries track Node.js `LTS releases
+<https://nodejs.org/en/about/releases/>`__, and support 14.x, and 16.x.
 
 .. _issues--help:
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:eslint": "eslint --config .eslintrc.js \"src/\" \"e2e/\"",
     "lint:prettier": "prettier \"{src,e2e}/**/*.{ts,tsx,js,jsx,css}\" \"**/*.{md,mdx,yml}\"",
     "test": "jest --selectProjects browser",
-    "test:e2e:node": "jest --selectProjects e2e-node --collectCoverage false",
+    "test:e2e:node": "jest --selectProjects e2e-node --testTimeout 15000 --collectCoverage false",
     "test:e2e:browser": "playwright test",
     "test:e2e:browser:setup": "cd e2e/browser/test-app && npm ci",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
This follows up from #586, clarifying the wording.