### PR TITLE
Fix/end to end tests

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -175,6 +175,8 @@ describe("End-to-end verifiable credentials tests for environment", () => {
             fetch: session.fetch,
           }
         );
+        // Jest is confused by the conditional test block.
+        // eslint-disable-next-line jest/no-standalone-expect
         expect(result).not.toHaveLength(0);
       }
     );

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -191,10 +191,7 @@ export function concatenateContexts(...contexts: unknown[]): unknown {
  */
 export const defaultContext = ["https://www.w3.org/2018/credentials/v1"];
 
-export const defaultCredentialTypes = [
-  "VerifiableCredential",
-  "SolidCredential",
-];
+export const defaultCredentialTypes = ["VerifiableCredential"];
 
 /**
  * A Verifiable Credential API configuration details.

--- a/src/verify/verify.test.ts
+++ b/src/verify/verify.test.ts
@@ -38,7 +38,7 @@ const MOCK_VC = {
   ],
   id: "https://example.com/id",
   issuer: "https://example.com/issuer",
-  type: ["VerifiableCredential", "SolidCredential", "SolidAccessGrant"],
+  type: ["VerifiableCredential", "SolidAccessGrant"],
   issuanceDate: "2021-05-26T16:40:03",
   expirationDate: "2021-06-09T16:40:03",
   credentialSubject: {


### PR DESCRIPTION
End-to-end tests are currently failing against dev-next due to some JSON-LD misalignments previously documented in https://github.com/inrupt/solid-client-access-grants-js/commit/25ac1849252249126a923d24e2a3bd779b16e679. This PR fixes these tests.