### PR TITLE
Re-enable dev-next query tests

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -148,38 +148,31 @@ describe("End-to-end verifiable credentials tests for environment", () => {
   });
 
   describe("lookup VCs", () => {
-    const testIf = (condition: boolean) => (condition ? it : it.skip);
-    // This test currently runs into issues with dev-next. These are being investigated,
-    // but in the meantime this test will be skipped so that we have tests in a clean
-    // state.
-    testIf(env.environment !== "ESS Dev-Next")(
-      "returns all VC issued matching a given shape",
-      async () => {
-        const result = await getVerifiableCredentialAllFromShape(
-          new URL("derive", env.vcProvider).href,
-          {
-            "@context": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://schema.inrupt.com/credentials/v1.jsonld",
-            ],
-            type: ["VerifiableCredential", "SolidAccessGrant"],
-            credentialSubject: {
-              id: vcSubject,
-              providedConsent: {
-                hasStatus:
-                  "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-              },
+    it("returns all VC issued matching a given shape", async () => {
+      const result = await getVerifiableCredentialAllFromShape(
+        new URL("derive", env.vcProvider).href,
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld",
+          ],
+          type: ["VerifiableCredential", "SolidAccessGrant"],
+          credentialSubject: {
+            id: vcSubject,
+            providedConsent: {
+              hasStatus:
+                "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
             },
           },
-          {
-            fetch: session.fetch,
-          }
-        );
-        // Jest is confused by the conditional test block.
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(result).not.toHaveLength(0);
-      }
-    );
+        },
+        {
+          fetch: session.fetch,
+        }
+      );
+      // Jest is confused by the conditional test block.
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(result).not.toHaveLength(0);
+    });
   });
 
   describe("revoke VCs", () => {

--- a/src/issue/issue.test.ts
+++ b/src/issue/issue.test.ts
@@ -385,4 +385,40 @@ describe("issueVerifiableCredential", () => {
       })
     );
   });
+
+  it("normalizes the issued VC", async () => {
+    const mockedVc = mockDefaultCredential();
+    // Force unexpected VC shapes to check normalization.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    mockedVc.proof["https://w3id.org/security#proofValue"] =
+      mockedVc.proof.proofValue;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete mockedVc.proof.proofValue;
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify(mockedVc), {
+        status: 201,
+      })
+    );
+    const resultVc = await issueVerifiableCredential(
+      "https://some.endpoint",
+      { "@context": ["https://some-subject.context"] },
+      {
+        "@context": ["https://some-credential.context"],
+        type: ["some-type", "some-other-type"],
+      },
+      {
+        fetch: mockedFetch,
+      }
+    );
+    expect(resultVc.proof.proofValue).toBe(
+      mockDefaultCredential().proof.proofValue
+    );
+    expect(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      resultVc.proof["https://w3id.org/security#proofValue"]
+    ).toBeUndefined();
+  });
 });

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -33,6 +33,7 @@ import {
   concatenateContexts,
   defaultContext,
   defaultCredentialTypes,
+  normalizeVc,
 } from "../common/common";
 
 type OptionsType = {
@@ -102,7 +103,7 @@ async function internal_issueVerifiableCredential(
       `The VC issuing endpoint [${issuerEndpoint}] could not successfully issue a VC: ${response.status} ${response.statusText}`
     );
   }
-  const jsonData = await response.json();
+  const jsonData = normalizeVc(await response.json());
   if (isVerifiableCredential(jsonData)) {
     return jsonData;
   }

--- a/src/lookup/query.test.ts
+++ b/src/lookup/query.test.ts
@@ -22,7 +22,11 @@
 import { jest, it, describe, expect } from "@jest/globals";
 import { query, QueryByExample } from "./query";
 import type * as Fetcher from "../fetcher";
-import { mockDefaultPresentation } from "../common/common.mock";
+import {
+  mockDefaultCredential,
+  mockDefaultPresentation,
+  mockPartialPresentation,
+} from "../common/common.mock";
 
 jest.mock("../fetcher");
 
@@ -147,6 +151,40 @@ describe("query", () => {
           { fetch: mockedFetch }
         )
       ).resolves.toStrictEqual(mockDefaultPresentation());
+    });
+
+    it("normalizes the VP sent by the endpoint", async () => {
+      const mockedVc = mockDefaultCredential();
+      // Force unexpected VC shapes to check normalization.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      mockedVc.proof["https://w3id.org/security#proofValue"] =
+        mockedVc.proof.proofValue;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      delete mockedVc.proof.proofValue;
+      const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response(JSON.stringify(mockDefaultPresentation([mockedVc])), {
+          status: 200,
+        })
+      );
+      const resultVp = await query(
+        "https://example.org/query",
+        { query: [mockRequest] },
+        { fetch: mockedFetch }
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(resultVp.verifiableCredential![0].proof.proofValue).toBe(
+        mockDefaultCredential().proof.proofValue
+      );
+      expect(
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        resultVp.verifiableCredential![0].proof[
+          "https://w3id.org/security#proofValue"
+        ]
+      ).toBeUndefined();
     });
   });
 });

--- a/src/lookup/query.test.ts
+++ b/src/lookup/query.test.ts
@@ -25,7 +25,6 @@ import type * as Fetcher from "../fetcher";
 import {
   mockDefaultCredential,
   mockDefaultPresentation,
-  mockPartialPresentation,
 } from "../common/common.mock";
 
 jest.mock("../fetcher");

--- a/src/lookup/query.ts
+++ b/src/lookup/query.ts
@@ -128,10 +128,9 @@ export async function query(
   }
   if (!isVerifiablePresentation(data)) {
     throw new Error(
-      `The holder [${queryEndpoint}] did not return a Verifiable Presentation: `
-      // ${JSON.stringify(
-      //   data
-      // )}`
+      `The holder [${queryEndpoint}] did not return a Verifiable Presentation: ${JSON.stringify(
+        data
+      )}`
     );
   }
   return data;

--- a/src/lookup/query.ts
+++ b/src/lookup/query.ts
@@ -22,6 +22,7 @@
 import {
   Iri,
   isVerifiablePresentation,
+  normalizeVp,
   VerifiableCredential,
   VerifiablePresentation,
 } from "../common/common";
@@ -119,7 +120,7 @@ export async function query(
 
   let data;
   try {
-    data = await response.json();
+    data = normalizeVp(await response.json());
   } catch (e) {
     throw new Error(
       `The holder [${queryEndpoint}] did not return a valid JSON response: parsing failed with error ${e}`
@@ -127,9 +128,10 @@ export async function query(
   }
   if (!isVerifiablePresentation(data)) {
     throw new Error(
-      `The holder [${queryEndpoint}] did not return a Verifiable Presentation: ${JSON.stringify(
-        data
-      )}`
+      `The holder [${queryEndpoint}] did not return a Verifiable Presentation: `
+      // ${JSON.stringify(
+      //   data
+      // )}`
     );
   }
   return data;

--- a/src/verify/verify.ts
+++ b/src/verify/verify.ts
@@ -30,6 +30,7 @@ import {
   isVerifiableCredential,
   isVerifiablePresentation,
   VerifiablePresentation,
+  normalizeVc,
 } from "../common/common";
 import fallbackFetch from "../fetcher";
 
@@ -52,7 +53,7 @@ async function dereferenceVc(
     );
   }
   try {
-    return await vcResponse.json();
+    return normalizeVc(await vcResponse.json());
   } catch (e) {
     throw new Error(
       `Parsing the value obtained when dereferencing [${vc.toString()}] as JSON failed: ${


### PR DESCRIPTION
The query end-to-end tests had been disabled previously due to a server-side issue that is now resolved. A small misalignment in the shape of the VC returned is caused by the server using native JSON-LD vs the client using plain JSON, which is a know issue we are working on.