### PR TITLE
chore: retry e2e tests

### DIFF
--- a/e2e/node/jest.e2e.setup.ts
+++ b/e2e/node/jest.e2e.setup.ts
@@ -20,6 +20,7 @@
 //
 
 import { setupEnv } from "@inrupt/internal-test-env";
+import { jest } from "@jest/globals";
 
 // Fail fast on dotenv:
 setupEnv();

--- a/e2e/node/jest.e2e.setup.ts
+++ b/e2e/node/jest.e2e.setup.ts
@@ -23,3 +23,8 @@ import { setupEnv } from "@inrupt/internal-test-env";
 
 // Fail fast on dotenv:
 setupEnv();
+
+if (process.env.CI === "true") {
+  // Tests running in the CI runners tend to be more flaky.
+  jest.retryTimes(5, { logErrorsBeforeRetry: true });
+}


### PR DESCRIPTION
So we don't have to hit retry 3 times just to get PRs like https://github.com/inrupt/solid-client-vc-js/pull/698 through.