### PR TITLE
Revert "chore(deps-dev): bump @inrupt/jest-jsdom-polyfills from 1.7.0 to 1.8.0 (#713)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -858,15 +858,15 @@
       }
     },
     "node_modules/@inrupt/jest-jsdom-polyfills": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.8.0.tgz",
-      "integrity": "sha512-2LKAkafRVpGzQARfK42Y4jCD2ZcTFARiz3HQzO1eZnKOF5V1OF4V+Ls3uCH/LUVA9K1pzDZr7zpiH++c6YbRcw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.7.0.tgz",
+      "integrity": "sha512-oH2eZ48PlgkdDDTRKa+rRAM13FDBqcW3y2B0Hh1s5+NCIjIiRLVEFhTCZ4LYYhkjFVU5g2HFhWxYrHQYJceZyQ==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.4",
         "@web-std/file": "^3.0.2",
-        "undici": "^5.22.1"
+        "undici": "^5.20.0"
       }
     },
     "node_modules/@inrupt/oidc-client": {
@@ -8344,14 +8344,14 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=12.18"
       }
     },
     "node_modules/universalify": {
@@ -9435,15 +9435,15 @@
       }
     },
     "@inrupt/jest-jsdom-polyfills": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.8.0.tgz",
-      "integrity": "sha512-2LKAkafRVpGzQARfK42Y4jCD2ZcTFARiz3HQzO1eZnKOF5V1OF4V+Ls3uCH/LUVA9K1pzDZr7zpiH++c6YbRcw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.7.0.tgz",
+      "integrity": "sha512-oH2eZ48PlgkdDDTRKa+rRAM13FDBqcW3y2B0Hh1s5+NCIjIiRLVEFhTCZ4LYYhkjFVU5g2HFhWxYrHQYJceZyQ==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.4",
         "@web-std/file": "^3.0.2",
-        "undici": "^5.22.1"
+        "undici": "^5.20.0"
       }
     },
     "@inrupt/oidc-client": {
@@ -15051,9 +15051,9 @@
       }
     },
     "undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "requires": {
         "busboy": "^1.6.0"
       }


### PR DESCRIPTION
This reverts commit 7635bb9b5cb6ea3909ccf8f3e3efa59f1dbfccc0.
