### PR TITLE
chore(e2e): update node and browser e2e test to use new env

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -21,7 +21,7 @@ jobs:
         environment-name: ["ESS PodSpaces"]
         experimental: [false]
         include:
-          - environment-name: "ESS Dev-Next"
+          - environment-name: "ESS Dev-2-2"
             experimental: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - node-version: "20.x"
             experimental: true
-            environment-name: "ESS Dev-Next"
+            environment-name: "ESS Dev-2-2"
             os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       },
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^2.0.0",
-        "@inrupt/internal-playwright-helpers": "^2.0.0",
-        "@inrupt/internal-test-env": "^2.0.0",
-        "@inrupt/jest-jsdom-polyfills": "^2.0.0",
+        "@inrupt/internal-playwright-helpers": "^2.0.4",
+        "@inrupt/internal-test-env": "^2.0.4",
+        "@inrupt/jest-jsdom-polyfills": "^2.0.4",
         "@playwright/test": "^1.28.1",
         "@rdfjs/dataset": "2.0.1",
         "@rdfjs/types": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   },
   "devDependencies": {
     "@inrupt/eslint-config-lib": "^2.0.0",
-    "@inrupt/internal-playwright-helpers": "^2.0.0",
-    "@inrupt/internal-test-env": "^2.0.0",
-    "@inrupt/jest-jsdom-polyfills": "^2.0.0",
+    "@inrupt/internal-playwright-helpers": "^2.0.4",
+    "@inrupt/internal-test-env": "^2.0.4",
+    "@inrupt/jest-jsdom-polyfills": "^2.0.4",
     "@playwright/test": "^1.28.1",
     "@rdfjs/dataset": "2.0.1",
     "@rdfjs/types": "^1.1.0",


### PR DESCRIPTION

This PR updates from the Dev-Next env for E2E test to the Dev-2-2 env.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
