### PR TITLE
Update e2e-browser.yml

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -7,10 +7,6 @@ env:
   CI: true
 jobs:
   e2e-browser:
-    # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
-    # Since all the other jobs of this workflow depend on this one, skipping it should
-    # skip the entire workflow.
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     environment:
       name: ${{ matrix.environment-name }}


### PR DESCRIPTION
Note that we are already skipping dependabot within the matrix so we don't need to skip the matrix itself.

This means that we can make each of the browser e2e tests required without blocking dependabot PRs from merging.