### PR TITLE
Fix mismatch between issued VC and query

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -168,7 +168,6 @@ describe("End-to-end verifiable credentials tests for environment", () => {
           },
         ),
       ]);
-
       await expect(
         getVerifiableCredentialAllFromShape(
           new URL("derive", env.vcProvider).href,
@@ -177,14 +176,7 @@ describe("End-to-end verifiable credentials tests for environment", () => {
               "https://www.w3.org/2018/credentials/v1",
               "https://schema.inrupt.com/credentials/v1.jsonld",
             ],
-            type: ["VerifiableCredential", "SolidAccessGrant"],
-            credentialSubject: {
-              id: vcSubject,
-              providedConsent: {
-                hasStatus:
-                  "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-              },
-            },
+            type: ["VerifiableCredential"],
           },
           {
             fetch: session.fetch,

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -168,6 +168,7 @@ describe("End-to-end verifiable credentials tests for environment", () => {
           },
         ),
       ]);
+
       await expect(
         getVerifiableCredentialAllFromShape(
           new URL("derive", env.vcProvider).href,


### PR DESCRIPTION
The test was issuing an Access Request, but requesting Access Grants, so it still failed for users not having any Access Grants issued.