### PR TITLE
Remove deprecated issue signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The following changes have been implemented but not released yet:
 - Parsing Verifiable Credentials. This allows the Verifiable Credential to be read using the RDF/JS DatasetCore API. This is a breaking change because the `VerifiableCredential` type now is also of type `DatasetCore`. Importantly, this dataset is not preserved when converting to verifiableCredentials a string and back doing `JSON.parse(JSON.stringify(verifiableCredential))`. We reccomend that developers set `returnLegacyJsonld` to `false` in functions such as `getVerifiableCredential` in order to avoid returning deprecated object properties. Instead developers should make use of the exported `getter` functions to get these attributes.
 - Use the global `fetch` function instead of `@inrupt/universal-fetch`. This means this library now only works
   with Node 18 and higher.
+- The deprecated signature of `issueVerifiableCredential` (including a `subjectId` parameter) is no longer supported. Please remove the extraneous parameter.
 - Due to changes in the rollup config, the `umd` output is now found at `dist/index.umd.js` rather than `umd/index.js`.
 
 ## [0.7.4](https://github.com/inrupt/solid-client-vc-js/releases/tag/v0.7.4) - 2023-11-17

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -171,7 +171,6 @@ describe("End-to-end verifiable credentials tests for environment", () => {
         ),
         issueVerifiableCredential(
           issuerService,
-          "http://example.org/my/subject/id",
           validSubjectClaims(),
           validCredentialClaims,
 
@@ -181,7 +180,6 @@ describe("End-to-end verifiable credentials tests for environment", () => {
         ),
         issueVerifiableCredential(
           issuerService,
-          "http://example.org/my/subject/id",
           validSubjectClaims(),
           validCredentialClaims,
 

--- a/src/issue/issue.test.ts
+++ b/src/issue/issue.test.ts
@@ -22,9 +22,7 @@
 import { jest, describe, it, expect } from "@jest/globals";
 import { defaultContext, defaultCredentialTypes } from "../common/common";
 import { mockDefaultCredential } from "../common/common.mock";
-import defaultIssueVerifiableCredential, {
-  issueVerifiableCredential,
-} from "./issue";
+import { issueVerifiableCredential } from "./issue";
 
 describe("issueVerifiableCredential", () => {
   it("uses the provided fetch if any", async () => {

--- a/src/issue/issue.test.ts
+++ b/src/issue/issue.test.ts
@@ -313,66 +313,6 @@ describe("issueVerifiableCredential", () => {
     );
   });
 
-  it("doesn't include the subject ID when using the deprecated signature", async () => {
-    const mockedFetch = jest.fn<typeof fetch>();
-    try {
-      await issueVerifiableCredential(
-        "https://some.endpoint",
-        "https://some.subject",
-        { "@context": ["https://some-subject.context"], aClaim: "a value" },
-        undefined,
-        {
-          fetch: mockedFetch,
-        },
-      );
-      // eslint-disable-next-line no-empty
-    } catch (_e) {}
-    expect(mockedFetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        body: JSON.stringify({
-          credential: {
-            "@context": [...defaultContext, "https://some-subject.context"],
-            type: defaultCredentialTypes,
-            credentialSubject: {
-              // Note that the subject ID is not present
-              aClaim: "a value",
-            },
-          },
-        }),
-      }),
-    );
-  });
-
-  it("doesn't include the subject ID when using the deprecated default signature", async () => {
-    const mockedFetch = jest.fn<typeof fetch>();
-    try {
-      await defaultIssueVerifiableCredential(
-        "https://some.endpoint",
-        "https://some.subject",
-        { "@context": ["https://some-subject.context"], aClaim: "a value" },
-        undefined,
-        { fetch: mockedFetch },
-      );
-      // eslint-disable-next-line no-empty
-    } catch (_e) {}
-    expect(mockedFetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        body: JSON.stringify({
-          credential: {
-            "@context": [...defaultContext, "https://some-subject.context"],
-            type: defaultCredentialTypes,
-            credentialSubject: {
-              // Note that the subject ID is not present
-              aClaim: "a value",
-            },
-          },
-        }),
-      }),
-    );
-  });
-
   it("normalizes the issued VC", async () => {
     const mockedVc = mockDefaultCredential("http://example.org/my/sample/id");
     // Force unexpected VC shapes to check normalization.

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -37,60 +37,102 @@ import {
   // eslint-disable-next-line camelcase
   internal_getVerifiableCredentialFromResponse,
 } from "../common/common";
-import type { ParseOptions } from "../parser/jsonld";
+// import type { ParseOptions } from "../parser/jsonld";
 
 type OptionsType = {
   fetch?: typeof fetch;
   returnLegacyJsonld?: boolean;
 };
 
-// The following extracts the logic of issueVerifiableCredential to separate it
-// from the deprecation logic. It can be merged back in issueVerifiableCredential
-// when the deprecated signature is removed altogether.
-// eslint-disable-next-line camelcase
-async function internal_issueVerifiableCredential(
+/**
+ * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
+ * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
+ *
+ * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
+ * @param subjectId The identifier of the VC claims' subject.
+ * @param subjectClaims Claims about the subject that will be attested by the VC.
+ * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
+ * @param options
+ * - options.fetch: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * This can be typically used for authentication. Note that if it is omitted, and
+ * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
+ * is picked up.
+ * - options.returnLegacyJsonld: Include the normalized JSON-LD in the response
+ * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
+ * @since 0.1.0
+ */
+export async function issueVerifiableCredential(
   issuerEndpoint: Iri,
   subjectClaims: JsonLd,
   credentialClaims: JsonLd,
   options: {
     fetch?: typeof fetch;
     returnLegacyJsonld: false;
-  } & ParseOptions,
+  },
 ): Promise<DatasetWithId>;
 /**
+ * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
+ * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
+ *
+ * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
+ * @param subjectId The identifier of the VC claims' subject.
+ * @param subjectClaims Claims about the subject that will be attested by the VC.
+ * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
+ * @param options
+ * - options.fetch: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * This can be typically used for authentication. Note that if it is omitted, and
+ * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
+ * is picked up.
+ * - options.returnLegacyJsonld: Include the normalized JSON-LD in the response
+ * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
+ * @since 0.1.0
  * @deprecated Deprecated in favour of setting returnLegacyJsonld: false. This will be the default value in future
  * versions of this library.
  */
-async function internal_issueVerifiableCredential(
+export async function issueVerifiableCredential(
   issuerEndpoint: Iri,
   subjectClaims: JsonLd,
   credentialClaims?: JsonLd,
   options?: {
     fetch?: typeof fetch;
     returnLegacyJsonld?: true;
-  } & ParseOptions,
+    normalize?: (object: VerifiableCredentialBase) => VerifiableCredentialBase;
+  },
 ): Promise<VerifiableCredential>;
 /**
+ * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
+ * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
+ *
+ * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
+ * @param subjectId The identifier of the VC claims' subject.
+ * @param subjectClaims Claims about the subject that will be attested by the VC.
+ * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
+ * @param options
+ * - options.fetch: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * This can be typically used for authentication. Note that if it is omitted, and
+ * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
+ * is picked up.
+ * - options.returnLegacyJsonld: Include the normalized JSON-LD in the response
+ * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
+ * @since 0.1.0
  * @deprecated Deprecated in favour of setting returnLegacyJsonld: false. This will be the default value in future
  * versions of this library.
  */
-async function internal_issueVerifiableCredential(
+export async function issueVerifiableCredential(
   issuerEndpoint: Iri,
   subjectClaims: JsonLd,
   credentialClaims?: JsonLd,
   options?: {
     fetch?: typeof fetch;
     returnLegacyJsonld?: boolean;
-  } & ParseOptions,
+    normalize?: (object: VerifiableCredentialBase) => VerifiableCredentialBase;
+  },
 ): Promise<DatasetWithId>;
-async function internal_issueVerifiableCredential(
+export async function issueVerifiableCredential(
   issuerEndpoint: Iri,
   subjectClaims: JsonLd,
-  credentialClaims?: JsonLd,
-  options?: {
-    fetch?: typeof fetch;
-    returnLegacyJsonld?: boolean;
-  } & ParseOptions,
+  credentialClaims: JsonLd | undefined,
+  options?: OptionsType,
 ): Promise<DatasetWithId> {
   const internalOptions = { ...options };
   if (internalOptions.fetch === undefined) {
@@ -150,141 +192,6 @@ async function internal_issueVerifiableCredential(
     undefined,
     response,
     options,
-  );
-}
-
-/**
- * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
- * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
- *
- * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
- * @param subjectId The identifier of the VC claims' subject.
- * @param subjectClaims Claims about the subject that will be attested by the VC.
- * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
- * @param options
- * - options.fetch: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * This can be typically used for authentication. Note that if it is omitted, and
- * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
- * is picked up.
- * - options.returnLegacyJsonld: Include the normalized JSON-LD in the response
- * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
- * @since 0.1.0
- */
-export async function issueVerifiableCredential(
-  issuerEndpoint: Iri,
-  subjectClaims: JsonLd,
-  credentialClaims: JsonLd,
-  options: {
-    fetch?: typeof fetch;
-    returnLegacyJsonld: false;
-  },
-): Promise<DatasetWithId>;
-/**
- * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
- * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
- *
- * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
- * @param subjectId The identifier of the VC claims' subject.
- * @param subjectClaims Claims about the subject that will be attested by the VC.
- * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
- * @param options
- * - options.fetch: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * This can be typically used for authentication. Note that if it is omitted, and
- * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
- * is picked up.
- * - options.returnLegacyJsonld: Include the normalized JSON-LD in the response
- * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
- * @since 0.1.0
- * @deprecated Deprecated in favour of setting returnLegacyJsonld: false. This will be the default value in future
- * versions of this library.
- */
-export async function issueVerifiableCredential(
-  issuerEndpoint: Iri,
-  subjectClaims: JsonLd,
-  credentialClaims?: JsonLd,
-  options?: {
-    fetch?: typeof fetch;
-    returnLegacyJsonld?: true;
-    normalize?: (object: VerifiableCredentialBase) => VerifiableCredentialBase;
-  },
-): Promise<VerifiableCredential>;
-/**
- * Request that a given Verifiable Credential (VC) Issuer issues a VC containing
- * the provided claims. The VC Issuer is expected to implement the [W3C VC Issuer HTTP API](https://w3c-ccg.github.io/vc-api/issuer.html).
- *
- * @param issuerEndpoint The `/issue` endpoint of the VC Issuer.
- * @param subjectId The identifier of the VC claims' subject.
- * @param subjectClaims Claims about the subject that will be attested by the VC.
- * @param credentialClaims Claims about the credential itself, rather than its subject, e.g. credential type or expiration.
- * @param options
- * - options.fetch: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * This can be typically used for authentication. Note that if it is omitted, and
- * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
- * is picked up.
- * - options.returnLegacyJsonld: Include the normalized JSON-LD in the response
- * @returns the VC returned by the Issuer if the request is successful. Otherwise, an error is thrown.
- * @since 0.1.0
- * @deprecated Deprecated in favour of setting returnLegacyJsonld: false. This will be the default value in future
- * versions of this library.
- */
-export async function issueVerifiableCredential(
-  issuerEndpoint: Iri,
-  subjectClaims: JsonLd,
-  credentialClaims?: JsonLd,
-  options?: {
-    fetch?: typeof fetch;
-    returnLegacyJsonld?: boolean;
-    normalize?: (object: VerifiableCredentialBase) => VerifiableCredentialBase;
-  },
-): Promise<DatasetWithId>;
-/**
- * @deprecated Please remove the `subjectId` parameter
- */
-export async function issueVerifiableCredential(
-  issuerEndpoint: Iri,
-  subjectId: Iri,
-  subjectClaims: JsonLd,
-  credentialClaims?: JsonLd,
-  options?: {
-    fetch?: typeof fetch;
-    returnLegacyJsonld?: true;
-    normalize?: (object: VerifiableCredentialBase) => VerifiableCredentialBase;
-  },
-): Promise<VerifiableCredential>;
-/**
- * @deprecated Please remove the `subjectId` parameter
- */
-export async function issueVerifiableCredential(
-  issuerEndpoint: Iri,
-  subjectId: Iri,
-  subjectClaims: JsonLd,
-  credentialClaims?: JsonLd,
-  options?: OptionsType,
-): Promise<DatasetWithId>;
-// The signature of the implementation here is a bit confusing, but it avoid
-// breaking changes until we remove the `subjectId` completely from the API
-export async function issueVerifiableCredential(
-  issuerEndpoint: Iri,
-  subjectIdOrClaims: Iri | JsonLd,
-  subjectOrCredentialClaims: JsonLd | undefined,
-  credentialClaimsOrOptions?: JsonLd | OptionsType,
-  options?: OptionsType,
-): Promise<DatasetWithId> {
-  if (typeof subjectIdOrClaims === "string") {
-    // The function has been called with the deprecated signature, and the
-    // subjectOrCredentialClaims parameter should be ignored.
-    return internal_issueVerifiableCredential(
-      issuerEndpoint,
-      subjectOrCredentialClaims as JsonLd,
-      credentialClaimsOrOptions as JsonLd,
-      options,
-    );
-  }
-  return internal_issueVerifiableCredential(
-    issuerEndpoint,
-    subjectIdOrClaims,
-    subjectOrCredentialClaims,
-    credentialClaimsOrOptions as OptionsType,
   );
 }
 

--- a/src/issue/issue.ts
+++ b/src/issue/issue.ts
@@ -37,7 +37,6 @@ import {
   // eslint-disable-next-line camelcase
   internal_getVerifiableCredentialFromResponse,
 } from "../common/common";
-// import type { ParseOptions } from "../parser/jsonld";
 
 type OptionsType = {
   fetch?: typeof fetch;


### PR DESCRIPTION
The deprecated signature of `issueVerifiableCredential` (including a `subjectId` parameter) is no longer supported.