### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The following changes have been implemented but not released yet:
 
 - Export type `VerifiableCredentialApiConfiguration`, which is part of the public API but was missing from the exports.
 
-
 ## [1.0.0](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.0.0) - 2023-12-21
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The following changes have been implemented but not released yet:
 
 ## Unreleased
 
+## [1.0.1](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.0.1) - 2024-01-17
+
+### Patch changes
+
+- Export type `VerifiableCredentialApiConfiguration`, which is part of the public API but was missing from the exports.
+
+
 ## [1.0.0](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.0.0) - 2023-12-21
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following changes have been implemented but not released yet:
 
 ## Unreleased
 
-## [1.0.1](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.0.1) - 2024-01-17
+## [1.0.2](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.0.2) - 2024-01-17
 
 ### Patch changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client-vc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client-vc",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client-vc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client-vc",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-vc",
   "description": "A library to act as a client to a server implementing the W3C VC HTTP APIs.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-vc",
   "description": "A library to act as a client to a server implementing the W3C VC HTTP APIs.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This jumps over v1.0.1, because I pushed the v1.0.1 tagby accident before merging the associated commit to main.