### PR TITLE
Add types to export entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## Unreleased
 
+### Patch changes
+
+- Added `types` in `exports` entries. This fixes issue #1028.
+
 ## [1.0.2](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.0.2) - 2024-01-17
 
 ### Patch changes

--- a/package.json
+++ b/package.json
@@ -34,14 +34,33 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     },
-    "./common": "./dist/common/common.mjs",
-    "./issue": "./dist/issue/issue.mjs",
-    "./derive": "./dist/lookup/derive.mjs",
-    "./query": "./dist/lookup/query.mjs",
-    "./revoke": "./dist/revoke/revoke.mjs",
-    "./verify": "./dist/verify/verify.mjs"
+    "./common": {
+      "import": "./dist/common/common.mjs",
+      "types": "./dist/common/common.d.ts"
+    },
+    "./issue": {
+      "import": "./dist/issue/issue.mjs",
+      "types": "./dist/issue/issue.d.ts"
+    },
+    "./derive": {
+      "import": "./dist/lookup/derive.mjs",
+      "types": "./dist/lookup/derive.d.ts"
+    },
+    "./query": {
+      "import": "./dist/lookup/query.mjs",
+      "types": "./dist/lookup/query.d.ts"
+    },
+    "./revoke": {
+      "import": "./dist/revoke/revoke.mjs",
+      "types": "./dist/revoke/revoke.d.ts"
+    },
+    "./verify": {
+      "import": "./dist/verify/verify.mjs",
+      "types": "./dist/verify/verify.d.ts"
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
Fixes #1028.

Add `types` field to `exports`, both the default export (`.`) and submodule exports.

- [X] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.