### PR TITLE
Add groups to simplify dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,17 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "typedoc-plugin-markdown"
         update-types: ["version-update:semver-major"]
+    groups:
+      internal-tooling:
+        patterns:
+          - "@inrupt/internal-*"
+          - "@inrupt/base-*"
+          - "@inrupt/jest-*"
+          - "@inrupt/eslint-*"
+      external-types:
+        patterns:
+          - "@types/*"
+
   - package-ecosystem: "npm"
     # Upgrade dependencies for the browser-based test app.
     directory: "/e2e/browser/test-app"
@@ -21,6 +32,11 @@ updates:
     ignore:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
+    groups:
+      external-types:
+        patterns:
+          - "@types/*"
+
   # Enable version updates for the website tooling
   - package-ecosystem: "pip"
     # Look for `package.json` and `lock` files in the `root` directory
@@ -28,6 +44,7 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "weekly"
+
   # Enable version updates for our CI tooling
   - package-ecosystem: "github-actions"
     # Look for `package.json` and `lock` files in the `root` directory


### PR DESCRIPTION
Creates dependabot groups for:
* all libraries from typescript-sdk-tools
* external type definitions

