### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,5 +33,4 @@ This PR bumps the version to <version number>.
   - the CHANGELOG update.
   - the version update.
   - `@since` annotations.
-- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
-- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
+- [ ] Once this PR is merged, I will push a tag matching the new version number when creating a new Github release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The following changes have been implemented but not released yet:
 
 ## Unreleased
 
+## [1.1.0](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.1.0) - 2024-09-03
+
 ### New feature
 
 - Integrate @inrupt/solid-client-errors for handling HTTP errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client-vc",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client-vc",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-vc",
   "description": "A library to act as a client to a server implementing the W3C VC HTTP APIs.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",

--- a/src/verify/verify.ts
+++ b/src/verify/verify.ts
@@ -191,7 +191,7 @@ async function asDataset(
  * - `options.challenge`: Pass a challenge
  *
  * @returns a JSON-shaped validation report structured accoring to the [VP Verifier API](https://w3c-ccg.github.io/vc-api/verifier.html#operation/verifyPresentation).
- * @since
+ * @since 0.6.0
  */
 export async function isValidVerifiablePresentation(
   verificationEndpoint: string | null,


### PR DESCRIPTION
This PR bumps the version to 1.1.0.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.