### PR TITLE
Release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The following changes have been implemented but not released yet:
 
 ## Unreleased
 
+## [1.1.2](https://github.com/inrupt/solid-client-vc-js/releases/tag/v1.1.2) - 2024-10-22
+
 ### Patch changes
 
 - Added support for the `https://schema.inrupt.com/credentials/v2.jsonld` JSON-LD context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client-vc",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client-vc",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-vc",
   "description": "A library to act as a client to a server implementing the W3C VC HTTP APIs.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This PR bumps the version to v1.1.2.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [X] Once this PR is merged, I will push a tag matching the new version number when creating a new Github release.
