### PR TITLE
Pin 3rd party GH Actions to commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,7 @@ jobs:
         with:
           name: code-coverage-ubuntu-latest-22.x
           path: coverage/
-      # Note: sonarcloud doesn't publish a major version tag, which is best practice for github actions.
-      - uses: SonarSource/sonarcloud-github-action@v5
+      - uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This pins third-party GH actions to commit hashes, as described in the [GitHub Actions documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)