### PR TITLE
Setup staged publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,5 @@ jobs:
       # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest
       - run: npm ci
-      - run: npm publish
+      - run: npm stage publish
+      - run: echo "The package has been staged, go to https://www.npmjs.com to publish it."

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,12 +25,6 @@ import { createRequire } from "node:module";
 // so `require` is not available. Use createRequire for require.resolve calls.
 const esmRequire = createRequire(import.meta.url);
 
-import { createRequire } from "node:module";
-
-// Jest 30 loads .ts config files as ESM via Node's native TypeScript support,
-// so `require` is not available. Use createRequire for require.resolve calls.
-const esmRequire = createRequire(import.meta.url);
-
 type ArrayElement<MyArray> = MyArray extends Array<infer T> ? T : never;
 
 const baseConfig: ArrayElement<NonNullable<Config["projects"]>> = {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,6 +19,11 @@
 //
 
 import type { Config } from "jest";
+import { createRequire } from "node:module";
+
+// Jest 30 loads .ts config files as ESM via Node's native TypeScript support,
+// so `require` is not available. Use createRequire for require.resolve calls.
+const esmRequire = createRequire(import.meta.url);
 
 import { createRequire } from "node:module";
 


### PR DESCRIPTION
Enforces an operator intervention (gated by 2FA) to publish the package after the automated CI staged it.

This mirrors the change made in `solid-client-errors-js` (inrupt/solid-client-errors-js#619): the release workflow now runs `npm stage publish` instead of `npm publish`, so a human must complete publication on npmjs.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)