### PR TITLE
Install latest NPM for staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,9 @@ jobs:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
           cache: npm
-      # Ensure npm 11.5.1 or later for trusted publishing
+      # Ensure npm 11.15.0 or later for staged publishing
       - run: npm install -g npm@latest
+      - run: npm --version
       - run: npm ci
       - run: npm stage publish
       - run: echo "The package has been staged, go to https://www.npmjs.com to publish it."


### PR DESCRIPTION
Aligns the release workflow with [`typescript-sdk-tools@c27952c`](https://github.com/inrupt/typescript-sdk-tools/commit/c27952cb73f08af8259e20385865c56f9c8e6df9) so that staged publishing uses a recent enough npm.

- Update the comment to reflect that staged publishing requires npm 11.15.0 or later (previously referenced 11.5.1 for trusted publishing).
- Add `npm --version` after installing the latest npm, for diagnostics in the release logs.

The `npm install -g npm@latest` step was already present, so the latest npm is already installed; this brings the workflow in line with the reference commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)